### PR TITLE
feat(auth): table user_scopes + login_siren — fondation multi-SIRET (GEN-686) [T1/6]

### DIFF
--- a/api/src/db/migrations/20260718100000-create-user-scopes.sql
+++ b/api/src/db/migrations/20260718100000-create-user-scopes.sql
@@ -1,0 +1,39 @@
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE auth.user_scopes (
+  _id          serial PRIMARY KEY,
+  user_id      int  NOT NULL REFERENCES auth.users(_id) ON DELETE CASCADE,
+  operator_id  int  NULL REFERENCES operator.operators(_id),
+  territory_id int  NULL REFERENCES territory.territory_group(_id),
+  is_default   boolean NOT NULL DEFAULT false,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  scope_type   text GENERATED ALWAYS AS (CASE WHEN operator_id IS NOT NULL THEN 'o' ELSE 't' END) STORED,
+  CHECK (num_nonnulls(operator_id, territory_id) = 1)
+);
+CREATE UNIQUE INDEX user_scopes_territory_key       ON auth.user_scopes(user_id, territory_id) WHERE territory_id IS NOT NULL;
+CREATE UNIQUE INDEX user_scopes_single_operator_key ON auth.user_scopes(user_id)               WHERE operator_id  IS NOT NULL;
+CREATE UNIQUE INDEX user_scopes_one_default_key     ON auth.user_scopes(user_id)               WHERE is_default;
+ALTER TABLE auth.user_scopes
+  ADD CONSTRAINT user_scopes_homogeneous_excl EXCLUDE USING gist (user_id WITH =, scope_type WITH <>);
+CREATE INDEX user_scopes_operator_idx  ON auth.user_scopes(operator_id)  WHERE operator_id  IS NOT NULL;
+CREATE INDEX user_scopes_territory_idx ON auth.user_scopes(territory_id) WHERE territory_id IS NOT NULL;
+
+ALTER TABLE auth.users ADD COLUMN login_siren varchar(9);
+
+-- backfill idempotent, opérateur prioritaire sur both-set
+INSERT INTO auth.user_scopes (user_id, operator_id, is_default)
+SELECT u._id, u.operator_id, true FROM auth.users u
+WHERE u.operator_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+
+INSERT INTO auth.user_scopes (user_id, territory_id, is_default)
+SELECT u._id, u.territory_id, true FROM auth.users u
+WHERE u.territory_id IS NOT NULL AND u.operator_id IS NULL
+  AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+
+UPDATE auth.users u SET login_siren = LEFT(COALESCE(o.siret, c.siret), 9)
+FROM auth.users src
+LEFT JOIN operator.operators o ON o._id = src.operator_id
+LEFT JOIN territory.territory_group g ON g._id = src.territory_id
+LEFT JOIN company.companies c ON c._id = g.company_id
+WHERE u._id = src._id;

--- a/api/src/pdc/providers/migration/migrations.ts
+++ b/api/src/pdc/providers/migration/migrations.ts
@@ -28,7 +28,12 @@ export async function migrateSQL(connectionString: string, path: string, verbose
       }
 
       const statements: string = await readTextFile(filepath);
-      const transaction = conn.createTransaction(`migration-${td.substring(1)}`);
+      // Connexion dédiée par migration : une migration en échec avortée laisse la
+      // connexion dans un état corrompu (deno-postgres) qui casse les migrations
+      // suivantes sur la connexion partagée. On isole donc chaque migration.
+      const migClient = new PgClient(connectionString);
+      await migClient.connect();
+      const transaction = migClient.createTransaction(`migration-${td.substring(1)}`);
       await transaction.begin();
 
       try {
@@ -37,7 +42,6 @@ export async function migrateSQL(connectionString: string, path: string, verbose
         await transaction.queryArray`INSERT INTO public.migrations (name, run_on) VALUES (${td}, NOW())`;
         await transaction.commit();
       } catch (e) {
-        // migration is rollbacked if an error occurs !
         // There's no way to catch the database error to log it.
         // Run the file with psql to debug...
         logger.error(`Error in migration: ${td}`);
@@ -46,6 +50,8 @@ export async function migrateSQL(connectionString: string, path: string, verbose
         } else {
           logger.error("An unknown error occurred");
         }
+      } finally {
+        await migClient.end();
       }
     }
   } catch (e) {

--- a/api/src/pdc/services/auth/providers/UserScopeRepository.integration.spec.ts
+++ b/api/src/pdc/services/auth/providers/UserScopeRepository.integration.spec.ts
@@ -1,0 +1,95 @@
+import { assertEquals, assertRejects } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+
+import sql from "@/lib/pg/sql.ts";
+import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/dbMacro.ts";
+
+import { UserScopeRepository } from "./UserScopeRepository.ts";
+
+describe("UserScopeRepository", () => {
+  let db: DenoDbContext;
+  let repository: UserScopeRepository;
+  const { before, after } = makeDenoDbBeforeAfter();
+  let seq = 0;
+  const seededOperatorId = 1; // maxiCovoit (seeds)
+
+  // Crée un territory_group rattaché à la company seed (dinum, _id=1).
+  async function ensureTerritory(id: number): Promise<void> {
+    await db.connection.query(sql`
+      INSERT INTO territory.territory_group (_id, company_id, name)
+      VALUES (${id}::int, 1::int, ${`Test territoire ${id}`}::varchar)
+      ON CONFLICT DO NOTHING
+    `);
+  }
+
+  // Crée un utilisateur nu (sans scope) et renvoie son _id.
+  async function createUser(role = "territory.admin"): Promise<number> {
+    const email = `user-scope-${++seq}@example.com`;
+    const rows = await db.connection.query<{ _id: number }>(sql`
+      INSERT INTO auth.users (email, firstname, lastname, password, status, role)
+      VALUES (${email}::varchar, 'U'::varchar, 'Scope'::varchar, 'x'::varchar, 'active'::auth.user_status_enum, ${role}::varchar)
+      RETURNING _id
+    `);
+    return rows[0]._id;
+  }
+
+  // Utilisateur avec un unique territoire par défaut.
+  async function seedUserWithTerritory(territoryId: number): Promise<number> {
+    const uid = await createUser();
+    await ensureTerritory(territoryId);
+    await repository.addTerritory(uid, territoryId, true);
+    return uid;
+  }
+
+  beforeAll(async () => {
+    db = await before();
+    repository = new UserScopeRepository(db.connection);
+  });
+
+  afterAll(async () => {
+    await after(db);
+  });
+
+  it("findDefault returns the default scope", async () => {
+    const uid = await seedUserWithTerritory(200);
+    assertEquals(await repository.findDefault(uid), { territory_id: 200 });
+  });
+
+  it("userHasTerritory is false for a non-granted territory", async () => {
+    const uid = await seedUserWithTerritory(201);
+    assertEquals(await repository.userHasTerritory(uid, 999), false);
+    assertEquals(await repository.userHasTerritory(uid, 201), true);
+  });
+
+  it("removeTerritory promotes another scope as default", async () => {
+    const uid = await createUser();
+    await ensureTerritory(202);
+    await ensureTerritory(203);
+    await repository.addTerritory(uid, 202, true);
+    await repository.addTerritory(uid, 203, false);
+
+    await repository.removeTerritory(uid, 202);
+
+    assertEquals(await repository.userHasTerritory(uid, 202), false);
+    assertEquals(await repository.findDefault(uid), { territory_id: 203 });
+  });
+
+  it("removeTerritory refuses to drop the last scope", async () => {
+    const uid = await seedUserWithTerritory(204);
+    await assertRejects(() => repository.removeTerritory(uid, 204));
+    assertEquals(await repository.userHasTerritory(uid, 204), true);
+  });
+
+  it("refuses a second operator scope (single_operator constraint)", async () => {
+    const uid = await createUser("operator.admin");
+    await repository.setOperator(uid, seededOperatorId);
+    await assertRejects(() => repository.setOperator(uid, seededOperatorId));
+  });
+
+  it("refuses mixing an operator and a territory scope (homogeneity constraint)", async () => {
+    const uid = await createUser("operator.admin");
+    await repository.setOperator(uid, seededOperatorId);
+    await ensureTerritory(205);
+    await assertRejects(() => repository.addTerritory(uid, 205, false));
+  });
+});

--- a/api/src/pdc/services/auth/providers/UserScopeRepository.ts
+++ b/api/src/pdc/services/auth/providers/UserScopeRepository.ts
@@ -1,0 +1,164 @@
+import { provider } from "@/ilos/common/index.ts";
+import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
+import sql, { raw } from "@/lib/pg/sql.ts";
+
+// Périmètre autorisé d'un utilisateur (operator_id XOR territory_id).
+export type UserScope = {
+  operator_id?: number;
+  territory_id?: number;
+  label: string;
+  siret?: string;
+};
+
+// Scope par défaut : identifiants seuls, pour seeder le contexte actif au login.
+export type DefaultScope = { operator_id?: number; territory_id?: number };
+
+type ScopeRow = {
+  operator_id: number | null;
+  territory_id: number | null;
+  label: string | null;
+  siret: string | null;
+};
+
+@provider()
+export class UserScopeRepository {
+  public readonly table = "auth.user_scopes";
+  public readonly territoryTable = "territory.territory_group";
+  public readonly operatorTable = "operator.operators";
+  public readonly companyTable = "company.companies";
+
+  constructor(protected denoConnection: DenoPostgresConnection) {}
+
+  // Liste des périmètres autorisés, défaut en tête, avec libellé/SIRET d'affichage.
+  async findByUser(userId: number): Promise<UserScope[]> {
+    const rows = await this.denoConnection.query<ScopeRow>(sql`
+      SELECT
+        us.operator_id,
+        us.territory_id,
+        COALESCE(o.name, t.name) AS label,
+        COALESCE(o.siret, c.siret) AS siret
+      FROM ${raw(this.table)} us
+      LEFT JOIN ${raw(this.operatorTable)} o ON o._id = us.operator_id
+      LEFT JOIN ${raw(this.territoryTable)} t ON t._id = us.territory_id
+      LEFT JOIN ${raw(this.companyTable)} c ON c._id = t.company_id
+      WHERE us.user_id = ${userId}
+      ORDER BY us.is_default DESC, us._id ASC
+    `);
+
+    return rows.map((r) => this.toScope(r));
+  }
+
+  // Scope par défaut (is_default), fallback MIN(_id) pour ne jamais casser le login.
+  async findDefault(userId: number): Promise<DefaultScope | null> {
+    const rows = await this.denoConnection.query<{ operator_id: number | null; territory_id: number | null }>(sql`
+      SELECT operator_id, territory_id
+      FROM ${raw(this.table)}
+      WHERE user_id = ${userId}
+      ORDER BY is_default DESC, _id ASC
+      LIMIT 1
+    `);
+    if (!rows.length) return null;
+    return this.toDefault(rows[0]);
+  }
+
+  // Revalidation de la bascule : match strict sur territory_id (jamais operator_id → anti-IDOR).
+  async userHasTerritory(userId: number, territoryId: number): Promise<boolean> {
+    const rows = await this.denoConnection.query<{ one: number }>(sql`
+      SELECT 1 AS one
+      FROM ${raw(this.table)}
+      WHERE user_id = ${userId} AND territory_id = ${territoryId}
+      LIMIT 1
+    `);
+    return rows.length > 0;
+  }
+
+  // Ajoute un territoire ; si défaut, dégrade l'ancien défaut dans la même transaction.
+  async addTerritory(userId: number, territoryId: number, isDefault = false): Promise<void> {
+    if (!isDefault) {
+      await this.denoConnection.query(sql`
+        INSERT INTO ${raw(this.table)} (user_id, territory_id, is_default)
+        VALUES (${userId}, ${territoryId}, false)
+      `);
+      return;
+    }
+
+    using client = await this.denoConnection.getClient().connect();
+    try {
+      await client.queryArray("BEGIN");
+      await client.queryObject({
+        text: `UPDATE ${this.table} SET is_default = false WHERE user_id = $1 AND is_default`,
+        args: [userId],
+      });
+      await client.queryObject({
+        text: `INSERT INTO ${this.table} (user_id, territory_id, is_default) VALUES ($1, $2, true)`,
+        args: [userId, territoryId],
+      });
+      await client.queryArray("COMMIT");
+    } catch (e) {
+      await client.queryArray("ROLLBACK");
+      throw e;
+    }
+  }
+
+  // Attribue l'unique opérateur (1:1) comme scope par défaut.
+  async setOperator(userId: number, operatorId: number): Promise<void> {
+    await this.denoConnection.query(sql`
+      INSERT INTO ${raw(this.table)} (user_id, operator_id, is_default)
+      VALUES (${userId}, ${operatorId}, true)
+    `);
+  }
+
+  // Retire un territoire ; promeut MIN(_id) si le défaut partait ; refuse le dernier scope.
+  async removeTerritory(userId: number, territoryId: number): Promise<void> {
+    using client = await this.denoConnection.getClient().connect();
+    try {
+      await client.queryArray("BEGIN");
+
+      const { rows: targets } = await client.queryObject<{ _id: number; is_default: boolean }>({
+        text: `SELECT _id, is_default FROM ${this.table} WHERE user_id = $1 AND territory_id = $2 FOR UPDATE`,
+        args: [userId, territoryId],
+      });
+      if (!targets.length) {
+        await client.queryArray("ROLLBACK");
+        return;
+      }
+
+      const { rows: counts } = await client.queryObject<{ n: number }>({
+        text: `SELECT count(*)::int AS n FROM ${this.table} WHERE user_id = $1`,
+        args: [userId],
+      });
+      if (counts[0].n <= 1) {
+        throw new Error("Impossible de retirer le dernier périmètre d'un utilisateur");
+      }
+
+      await client.queryObject({
+        text: `DELETE FROM ${this.table} WHERE _id = $1`,
+        args: [targets[0]._id],
+      });
+
+      if (targets[0].is_default) {
+        await client.queryObject({
+          text:
+            `UPDATE ${this.table} SET is_default = true WHERE _id = (SELECT MIN(_id) FROM ${this.table} WHERE user_id = $1)`,
+          args: [userId],
+        });
+      }
+
+      await client.queryArray("COMMIT");
+    } catch (e) {
+      await client.queryArray("ROLLBACK");
+      throw e;
+    }
+  }
+
+  private toDefault(r: { operator_id: number | null; territory_id: number | null }): DefaultScope {
+    return r.operator_id !== null ? { operator_id: r.operator_id } : { territory_id: r.territory_id as number };
+  }
+
+  private toScope(r: ScopeRow): UserScope {
+    const base = this.toDefault(r) as UserScope;
+    base.label = r.label ?? "";
+    if (r.siret !== null) base.siret = r.siret;
+    return base;
+  }
+}

--- a/docs/superpowers/plans/2026-07-18-multi-siret-gen686.md
+++ b/docs/superpowers/plans/2026-07-18-multi-siret-gen686.md
@@ -1,0 +1,318 @@
+# Multi-SIRET / multi-périmètre (GEN-686) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Découpler le SIRET de connexion (gate ProConnect) des périmètres d'un utilisateur, et permettre à un compte territoire de porter plusieurs territoires avec bascule de contexte — via une table pivot `auth.user_scopes`.
+
+**Architecture:** Table pivot `auth.user_scopes` = source de vérité des périmètres autorisés (défaut porté par `is_default`). Le scope actif vit en session serveur (Redis) ; l'aval (Catégorie B) lit `call.user.operator_id/territory_id` inchangé. `login_siren` sur `auth.users` sert uniquement le gate ProConnect. Bascule via `POST /auth/context` revalidée en DB. Migration expand/contract avec dual-write.
+
+**Tech Stack:** Deno 2.x, TypeScript, Express, ILOS (Inversify), PostgreSQL, Redis (express-session), ProConnect OIDC. Front : Next.js 15 / React 19 / DSFR (`app-partners`).
+
+## Global Constraints
+
+- **TDD** : test qui échoue → implémentation minimale → test passe → commit. (CLAUDE.md)
+- **Undercover** : aucune mention Claude/Anthropic dans commits/PR/trailers.
+- **Dépôt public** : aucun montant / nb de trajets / info entreprise non publique dans code/commits/PR.
+- **Jamais de commit sur `main`** : chaque tranche = worktree + PR.
+- **Français** : descriptions de PR et libellés en français ; « la spec » (féminin).
+- **Nommage SQL** : index `<table>_<cols>_idx`, contraintes uniques `<table>_<cols>_key` (jamais `ux_`). `timestamptz`.
+- **Fail-closed** : tout doute sur une autorisation → refus.
+- Spec de référence : `docs/superpowers/specs/2026-07-18-multi-siret-gen686-design.md`.
+
+---
+
+## Contrats partagés (FIGÉS — tous les agents s'y conforment)
+
+Ces signatures sont le contrat inter-tranches. Ne pas les renommer sans mettre à jour ce bloc.
+
+```typescript
+// Objet user en session (proxy/types/UserInterface.ts) — étendu par T2
+interface UserScope {
+  operator_id?: number;   // exclusif avec territory_id
+  territory_id?: number;
+  label: string;          // nom d'affichage (operator.name | territory_group.name)
+  siret?: string;         // SIRET du périmètre, affichage seul
+}
+interface UserInterface {
+  // ...existant...
+  operator_id?: number;      // = scope ACTIF (inchangé pour la Cat. B)
+  territory_id?: number;     // = scope ACTIF
+  scopes: UserScope[];       // AJOUT T2 — liste des périmètres autorisés (peindre l'UI)
+  // login_siren N'est PAS en session (consommé au gate, avant session)
+}
+
+// Permission (auth/config/permissions.ts) — AJOUT T4
+// "registry.user.manageScopes" détenue UNIQUEMENT par registry.admin
+
+// Route bascule (auth/AuthRouter.ts) — AJOUT T3
+// POST /auth/context  body: { territory_id: number }  → 200 { territory_id, label } | 401 | 403
+
+// Repository pivot (auth/providers/UserScopeRepository.ts) — CRÉÉ T1, consommé T2/T3/T4
+class UserScopeRepository {
+  // toutes requêtes paramétrées
+  findByUser(userId: number): Promise<UserScope[]>;                          // pour scopes[]
+  findDefault(userId: number): Promise<{operator_id?: number; territory_id?: number} | null>;
+  userHasTerritory(userId: number, territoryId: number): Promise<boolean>;   // revalidation /auth/context
+  addTerritory(userId: number, territoryId: number, isDefault?: boolean): Promise<void>;
+  removeTerritory(userId: number, territoryId: number): Promise<void>;       // promeut un autre défaut si besoin
+  setOperator(userId: number, operatorId: number): Promise<void>;
+}
+```
+
+**Ordre du merge train (stacking worktrees) :**
+```
+T1 (base = main)  →  merge en 1er
+T2 (base = T1)    ┐ parallèles après T1
+T4 (base = T1)    ┘
+T3 (base = T2)
+T5 (base = T2+T3)
+T6 (base = tout mergé + stabilisé)  →  drop colonnes
+```
+
+---
+
+## Structure de fichiers
+
+- `api/src/db/migrations/2026071810XXXX-create-user-scopes.sql` — **créé T1** : table + contraintes + backfill + `login_siren`.
+- `api/src/pdc/services/auth/providers/UserScopeRepository.ts` — **créé T1** : accès pivot.
+- `api/src/pdc/services/auth/providers/UserRepository.ts` — **modifié T2** : `authenticateByEmail` (seed défaut + scopes[] + login_siren + fallback).
+- `api/src/pdc/services/auth/providers/ProConnectOIDCProvider.ts` — **modifié T2** : `failsSirenCheck` fail-closed sur `login_siren`.
+- `api/src/pdc/services/auth/AuthRouter.ts` — **modifié T2** (`regenerate`) **+ T3** (route `/auth/context`).
+- `api/src/pdc/proxy/types/UserInterface.ts` — **modifié T2** : `scopes[]`.
+- `api/src/pdc/services/auth/providers/SessionRepository.ts` — **créé T3** : purge des sessions Redis d'un user.
+- `api/src/pdc/services/dashboard/providers/UsersRepository.ts` — **modifié T4** : list/create/update/delete via pivot + dual-write.
+- `api/src/pdc/services/dashboard/actions/users/*.ts` + `api/src/pdc/services/auth/config/permissions.ts` — **modifié T4** : gate `manageScopes` + hiérarchie de rôle.
+- `app-partners/src/components/layout/AppHeader.tsx`, `ProfilButton.tsx`, `AuthProvider.tsx`, `administration/tables/UsersTable.tsx` — **modifié T5**.
+- Migration `2026XXXX-drop-user-scope-legacy-columns.sql` — **créé T6**.
+
+---
+
+## Task 1 (T1) : Migration `auth.user_scopes` + backfill défensif + `UserScopeRepository`
+
+**Files:**
+- Create: `api/src/db/migrations/2026071810XXXX-create-user-scopes.sql`
+- Create: `api/src/pdc/services/auth/providers/UserScopeRepository.ts`
+- Test: `api/src/pdc/services/auth/providers/UserScopeRepository.integration.spec.ts`
+
+**Interfaces:**
+- Produces: table `auth.user_scopes`, colonne `auth.users.login_siren`, classe `UserScopeRepository` (cf. contrats partagés).
+
+- [ ] **Step 1 : Audit préalable des données sales** (à jouer via MCP `prod_ro` avant d'écrire la migration ; consigner les comptes)
+
+```sql
+SELECT count(*) FROM auth.users WHERE operator_id IS NOT NULL AND territory_id IS NOT NULL;   -- both-set
+SELECT count(*) FROM auth.users u WHERE u.operator_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM operator.operators o WHERE o._id = u.operator_id);             -- orphelins op
+SELECT count(*) FROM auth.users u WHERE u.territory_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM territory.territory_group g WHERE g._id = u.territory_id);      -- orphelins territoire
+```
+Si comptes > 0 : décider (nettoyer avant / exclure). Le backfill idempotent ci-dessous exclut déjà les both-set (priorité opérateur) et n'insère pas d'orphelins grâce aux FK actives (échec = donnée à nettoyer d'abord).
+
+- [ ] **Step 2 : Écrire la migration**
+
+```sql
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE auth.user_scopes (
+  _id          serial PRIMARY KEY,
+  user_id      int  NOT NULL REFERENCES auth.users(_id) ON DELETE CASCADE,
+  operator_id  int  NULL REFERENCES operator.operators(_id),
+  territory_id int  NULL REFERENCES territory.territory_group(_id),
+  is_default   boolean NOT NULL DEFAULT false,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  scope_type   text GENERATED ALWAYS AS (CASE WHEN operator_id IS NOT NULL THEN 'o' ELSE 't' END) STORED,
+  CHECK (num_nonnulls(operator_id, territory_id) = 1)
+);
+CREATE UNIQUE INDEX user_scopes_territory_key       ON auth.user_scopes(user_id, territory_id) WHERE territory_id IS NOT NULL;
+CREATE UNIQUE INDEX user_scopes_single_operator_key ON auth.user_scopes(user_id)               WHERE operator_id  IS NOT NULL;
+CREATE UNIQUE INDEX user_scopes_one_default_key     ON auth.user_scopes(user_id)               WHERE is_default;
+ALTER TABLE auth.user_scopes
+  ADD CONSTRAINT user_scopes_homogeneous_excl EXCLUDE USING gist (user_id WITH =, scope_type WITH <>);
+CREATE INDEX user_scopes_operator_idx  ON auth.user_scopes(operator_id)  WHERE operator_id  IS NOT NULL;
+CREATE INDEX user_scopes_territory_idx ON auth.user_scopes(territory_id) WHERE territory_id IS NOT NULL;
+
+ALTER TABLE auth.users ADD COLUMN login_siren varchar(9);
+
+-- backfill idempotent, opérateur prioritaire sur both-set
+INSERT INTO auth.user_scopes (user_id, operator_id, is_default)
+SELECT u._id, u.operator_id, true FROM auth.users u
+WHERE u.operator_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+
+INSERT INTO auth.user_scopes (user_id, territory_id, is_default)
+SELECT u._id, u.territory_id, true FROM auth.users u
+WHERE u.territory_id IS NOT NULL AND u.operator_id IS NULL
+  AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+
+UPDATE auth.users u SET login_siren = LEFT(COALESCE(o.siret, c.siret), 9)
+FROM (SELECT _id FROM auth.users) me
+LEFT JOIN operator.operators o ON o._id = (SELECT operator_id FROM auth.users WHERE _id = me._id)
+LEFT JOIN territory.territory_group g ON g._id = (SELECT territory_id FROM auth.users WHERE _id = me._id)
+LEFT JOIN company.companies c ON c._id = g.company_id
+WHERE u._id = me._id;
+```
+
+- [ ] **Step 3 : Contrôles post-migration bloquants** (dans la migration ou script de vérif)
+
+```sql
+-- chaque user avec scope a exactement 1 défaut
+SELECT count(*) FROM (SELECT user_id, count(*) FILTER (WHERE is_default) d FROM auth.user_scopes GROUP BY user_id) x WHERE d <> 1;  -- attendu 0
+```
+
+- [ ] **Step 4 : Test d'intégration `UserScopeRepository`** (DB via stack — cf. skill `tests-e2e`)
+
+```typescript
+// findDefault renvoie le scope is_default ; userHasTerritory=false pour un territoire non attribué
+it("findDefault returns the default scope", async () => {
+  const uid = await seedUserWithTerritory(200); // helper local
+  expect(await repo.findDefault(uid)).toEqual({ territory_id: 200 });
+});
+it("userHasTerritory is false for a non-granted territory", async () => {
+  const uid = await seedUserWithTerritory(200);
+  expect(await repo.userHasTerritory(uid, 999)).toBe(false);
+});
+```
+
+- [ ] **Step 5 : Run** `just dc_e2e` (ou recette d'intégration) — Expected: FAIL (repo absent).
+- [ ] **Step 6 : Implémenter `UserScopeRepository`** (requêtes paramétrées, pattern `PgRepositoryProvider` existant). `removeTerritory` : si la ligne retirée était `is_default`, promouvoir `MIN(_id)` restant dans la même transaction ; refuser si c'était le dernier scope.
+- [ ] **Step 7 : Run** l'intégration — Expected: PASS.
+- [ ] **Step 8 : Commit** `feat(auth): table user_scopes + backfill + login_siren (GEN-686)`
+
+---
+
+## Task 2 (T2) : Auth — seam login, `failsSirenCheck` fail-closed, `scopes[]`, regenerate
+
+**Files:**
+- Modify: `api/src/pdc/services/auth/providers/UserRepository.ts` (`authenticateByEmail`)
+- Modify: `api/src/pdc/services/auth/providers/ProConnectOIDCProvider.ts` (`failsSirenCheck`)
+- Modify: `api/src/pdc/proxy/types/UserInterface.ts` (+`scopes`)
+- Modify: `api/src/pdc/services/auth/AuthRouter.ts` (`session.regenerate` au callback)
+- Test: `*.spec.ts` associés
+
+**Interfaces:**
+- Consumes: `UserScopeRepository` (T1).
+- Produces: `session.user.scopes[]`, `session.user.{operator_id,territory_id}` = défaut ; `login_siren` renvoyé au gate.
+
+- [ ] **Step 1 : Test fail-closed** `failsSirenCheck`
+
+```typescript
+it("fails closed when login_siren is null and user is not registry.admin", () => {
+  expect(failsSirenCheck({ siren: "123456789" }, { login_siren: null, role: "territory.admin" })).toBe(true);
+});
+it("passes for registry.admin regardless of siren", () => {
+  expect(failsSirenCheck({ siren: "999999999" }, { login_siren: null, role: "registry.admin" })).toBe(false);
+});
+it("passes when proconnect siren matches login_siren", () => {
+  expect(failsSirenCheck({ siren: "123456789" }, { login_siren: "123456789", role: "territory.admin" })).toBe(false);
+});
+```
+
+- [ ] **Step 2 : Run** — FAIL.
+- [ ] **Step 3 : Implémenter** `failsSirenCheck` : `registry.admin` → `false` ; sinon `!login_siren` → `true` (fail-closed explicite, pas de `String(null)`) ; sinon comparer `proconnect.siren === login_siren`.
+- [ ] **Step 4 : Run** — PASS.
+- [ ] **Step 5 : Test `authenticateByEmail`** (intégration) : renvoie `login_siren`, seed `operator_id/territory_id` depuis `is_default`, `scopes[]` peuplé, fallback `MIN(_id)` si aucun `is_default`.
+- [ ] **Step 6 : Run** — FAIL.
+- [ ] **Step 7 : Implémenter** : match email inchangé ; charger défaut via `UserScopeRepository.findDefault` (fallback `MIN(_id)`) ; résoudre label/siret d'affichage ; charger `scopes[]` via `findByUser` ; renvoyer `login_siren`. Étendre `UserInterface` avec `scopes`.
+- [ ] **Step 8 : Anti-fixation** — au callback (`AuthRouter.ts:48-52`), `await new Promise(r => req.session.regenerate(r))` **avant** `req.session.user = user`, puis `save`.
+- [ ] **Step 9 : Run** tous les tests auth — PASS.
+- [ ] **Step 10 : Commit** `feat(auth): seam login multi-scope + gate fail-closed + regenerate (GEN-686)`
+
+---
+
+## Task 3 (T3) : Bascule `POST /auth/context` durcie + purge de session
+
+**Files:**
+- Modify: `api/src/pdc/services/auth/AuthRouter.ts` (route)
+- Create: `api/src/pdc/services/auth/providers/SessionRepository.ts` (purge Redis par user)
+- Test: `AuthRouter.integration.spec.ts`
+
+**Interfaces:**
+- Consumes: `UserScopeRepository.userHasTerritory` (T1), `session.user.scopes` (T2).
+- Produces: route `/auth/context` ; `SessionRepository.destroyByUser(userId)` (consommé T4).
+
+- [ ] **Step 1 : Tests route** (intégration, via supertest sur l'app)
+
+```typescript
+it("401 when no session user", async () => (await ctx.post("/auth/context", { territory_id: 1 })).status === 401);
+it("403 when territory not granted in DB", async () => { /* user a territoire 200, demande 999 */ });
+it("403 on op/territory id collision", async () => { /* scope operator_id:42, body territory_id:42 → 403 */ });
+it("200 and mutates active tuple (operator_id=null) when granted", async () => { /* territoire 200 accordé */ });
+it("refuses switch for operator-type user", async () => { /* 403/400 */ });
+```
+
+- [ ] **Step 2 : Run** — FAIL.
+- [ ] **Step 3 : Implémenter la route** : (1) `if (!req.session?.user) return 401` ; (2) refuser si user opérateur ; (3) **revalider en DB** `userHasTerritory(user._id, body.territory_id)` (match strict champ) sinon 403 ; (4) `req.session.user.territory_id = body.territory_id ; req.session.user.operator_id = null ; await save` ; (5) répondre `{ territory_id, label }`.
+- [ ] **Step 4 : Run** — PASS.
+- [ ] **Step 5 : Test `SessionRepository.destroyByUser`** : après purge, la session de l'user n'existe plus dans Redis.
+- [ ] **Step 6 : Implémenter** `SessionRepository` : indexer/scanner les sessions par `user_id` (préfixe connect-redis) et `destroy`. Voir `proxy/middlewares/sessionMiddleware.ts` pour le store.
+- [ ] **Step 7 : Run** — PASS.
+- [ ] **Step 8 : Commit** `feat(auth): route /auth/context revalidée DB + purge session (GEN-686)`
+
+---
+
+## Task 4 (T4) : CRUD dashboard via pivot + gate `manageScopes` + hiérarchie de rôle
+
+**Files:**
+- Modify: `api/src/pdc/services/dashboard/providers/UsersRepository.ts` (list/create/update/delete via pivot + **dual-write** colonnes dépréciées)
+- Modify: `api/src/pdc/services/auth/config/permissions.ts` (+`registry.user.manageScopes`)
+- Modify: `api/src/pdc/services/dashboard/actions/users/{Create,Update}UserAction.ts` + middleware
+- Test: `*.spec.ts` + intégration
+
+**Interfaces:**
+- Consumes: `UserScopeRepository` (T1), `SessionRepository.destroyByUser` (T3).
+- Produces: actions gardées ; liste dashboard via pivot.
+
+- [ ] **Step 1 : Test hiérarchie de rôle** : `territory.admin` créant `role: registry.admin` → **403**.
+- [ ] **Step 2 : Test gate champ privilégié** : `territory.admin` fournissant `login_siren`/octroi de scope → **403** ; `registry.admin` → OK.
+- [ ] **Step 3 : Test liste via pivot** : user multi-territoires visible des admins concernés, **une seule fois** (`DISTINCT`).
+- [ ] **Step 4 : Run** — FAIL.
+- [ ] **Step 5 : Implémenter** : permission `registry.user.manageScopes` (matrice `permissions.ts`, détenue par `registry.admin` seul) ; middleware rejetant `login_siren`/`scopes` si permission absente ; garde `roleRank(target) < roleRank(caller)` dans Create/Update ; requête liste `JOIN user_scopes … WHERE … = ANY(...) GROUP BY users._id` ; create/update **dual-write** `auth.users.operator_id/territory_id` **et** `user_scopes` ; delete/retrait de scope → `SessionRepository.destroyByUser`.
+- [ ] **Step 6 : Run** — PASS.
+- [ ] **Step 7 : Commit** `feat(dashboard): CRUD user multi-scope gaté registry.admin (GEN-686)`
+
+---
+
+## Task 5 (T5) : Front — bascule header + formulaire scopes
+
+**Files:**
+- Modify: `app-partners/src/components/layout/AppHeader.tsx` (combobox de bascule)
+- Modify: `app-partners/src/components/layout/ProfilButton.tsx` (nom au lieu de l'ID)
+- Modify: `app-partners/src/providers/AuthProvider.tsx` + `interfaces/auth.ts` (`scopes[]`, contexte actif)
+- Modify: `app-partners/src/app/administration/tables/UsersTable.tsx` (fieldset + table scopes + `login_siren`)
+- Test: tests composants existants (pattern du repo)
+
+**Interfaces:**
+- Consumes: `scopes[]` (`/auth/me`), route `POST /auth/context` (T3), actions CRUD (T4).
+
+- [ ] **Step 1 : Bascule header** : combobox recherchable (`Autocomplete` façon `SelectGeo.tsx`), affiche `scope.label`, coche l'actif ; 1 seul scope → badge statique. Appelle `/auth/context`, invalide les données (React Query), toast `success` + `aria-live`, confirmation si saisie en cours. Reconcilie sur `focus`/`visibilitychange`.
+- [ ] **Step 2 : Rappel du périmètre au point d'action** : `Callout`/`Badge` « Périmètre actif : {label} » en tête des écrans export/campagne + dans la modale de confirmation d'export.
+- [ ] **Step 3 : Formulaire user** : segmenter en `fieldset` (Identité / Connexion / Périmètres). `login_siren` : `label="SIREN de connexion (ProConnect)"`, hint « 9 chiffres — distinct du SIRET du territoire », validation `/^\d{9}$/`, pré-remplissage `LEFT(siret,9)`. Périmètres : `Table` + radio défaut + `Autocomplete` d'ajout. User opérateur → un seul `Select`, pas d'ajout. `territory.admin` → sections Connexion/Périmètres **masquées**.
+- [ ] **Step 4 : États limites** : 0 scope (`registry.admin` → « Administration RPC »), retrait du défaut (promotion), 403 → toast + refresh.
+- [ ] **Step 5 : Lint + tests front** (`just` recette front / `npm test`).
+- [ ] **Step 6 : Commit** `feat(app-partners): bascule de périmètre + formulaire multi-scope (GEN-686)`
+
+---
+
+## Task 6 (T6) : Contract — retrait dual-write + drop colonnes
+
+**Files:**
+- Modify: `api/src/pdc/services/dashboard/providers/UsersRepository.ts` (retirer le dual-write)
+- Create: `api/src/db/migrations/2026XXXX-drop-user-scope-legacy-columns.sql`
+
+- [ ] **Step 1 : Vérifier** qu'aucun code ne lit `auth.users.operator_id/territory_id` : `grep -rn "operator_id\|territory_id" api/src | grep -i "auth.users\|u\.\(operator\|territory\)_id"` → seuls les writes dual-write subsistent.
+- [ ] **Step 2 : Retirer le dual-write** de `UsersRepository` (create/update n'écrivent plus les colonnes).
+- [ ] **Step 3 : Migration** `ALTER TABLE auth.users DROP COLUMN operator_id, DROP COLUMN territory_id;`
+- [ ] **Step 4 : Run** suite d'intégration complète — PASS.
+- [ ] **Step 5 : Commit** `chore(auth): drop colonnes user scope legacy (GEN-686)`
+
+---
+
+## Self-review (couverture spec)
+
+- §4 modèle → T1 (table + toutes contraintes + login_siren). ✓
+- §5 auth (fail-closed, seam, regenerate) → T2. ✓
+- §6 bascule (401/403/typage/tuple complet/purge session) → T3. ✓
+- §7 CRUD (gate action, hiérarchie rôle, DISTINCT, promotion défaut, purge) → T4 + UX T5. ✓
+- §8 migration (audit, backfill idempotent, dual-write, contrôles bloquants) → T1 (expand) + T6 (contract). ✓
+- §9 tests → répartis par tranche. ✓
+- Contrats partagés (scopes[], permission, route, repo) → bloc figé en tête. ✓

--- a/docs/superpowers/specs/2026-07-18-multi-siret-gen686-design.md
+++ b/docs/superpowers/specs/2026-07-18-multi-siret-gen686-design.md
@@ -1,0 +1,216 @@
+# GEN-686 — Accès multi-SIRET / multi-périmètre — Design
+
+- **Ticket** : GEN-686 « Accès Multi-SIRET ATMB » (slice concret) ; GEN-473 « multi-compte territoire » (vision cible).
+- **Date** : 2026-07-18 · **Révision** : v2 (post-revues architecte BDD / sécurité / UX)
+- **Statut** : design validé, prêt pour le plan d'implémentation.
+- **Ambition** : concevoir le **modèle cible**, le **livrer incrémentalement** en démarrant par ATMB.
+
+> **Changelog v2** — Intègre les corrections des 3 revues expertes : durcissement sécurité (revalidation DB de la bascule, gate des champs privilégiés + hiérarchie de rôle, fail-closed `login_siren`, purge de session à la révocation, `regenerate` anti-fixation), backfill défensif + dual-write expand/contract (BDD), et refonte du flow d'édition (UX). Voir §12 pour la trace des findings.
+
+## 1. Problème & recadrage
+
+Besoin : un utilisateur doit avoir un **SIRET de connexion** (auth ProConnect) **découplé** des **périmètres** (opérateurs / territoires) sur lesquels il agit (campagnes, exports).
+
+Recadrage clé (exploration code) : **dans RPC, le SIRET n'est pas la clé de périmètre.** L'accès est scopé par `operator_id` **XOR** `territory_id` (→ codes géo). Le SIRET est *dérivé* au login et sert de **gate ProConnect** uniquement. « Multi-SIRET » = deux besoins séparables :
+
+1. **Connexion** — découpler le credential ProConnect du périmètre (gate SIREN plus 1:1).
+2. **Périmètre** — un compte porte plusieurs territoires et bascule entre eux (contexte actif).
+
+## 2. Décisions de cadrage
+
+| # | Décision | Choix |
+|---|----------|-------|
+| Ambition | ciblé / cible incrémental / big-bang | **Cible, incrémental** |
+| Exposition | contexte actif / agrégé | **Contexte actif** — un seul scope en session à la fois |
+| Gouvernance | admin RPC / délégation / self-service | **Octroi `registry.admin` uniquement (V1)** |
+| Modèle | chaînes SIRET / références d'entité | **Références d'entité** ; SIRET = gate connexion seulement |
+| Homogénéité | mixte / XOR | **XOR homogène** ; `role` unique sur `auth.users` ; **contrainte DB** (v2) |
+| Cardinalité | — | **Multi-territoires OUI ; multi-opérateurs NON** (opérateur 1:1) |
+| Modèle de contexte | session serveur durcie / URL par onglet | **Session serveur enforced + durcie** (v2, cf. §6) |
+
+### Règle métier centrale
+
+- User **territoire** → 1..N périmètres. User **opérateur** → **exactement 1** (1:1).
+- « Multi-SIRET connexion opérateur » (ATMB) = **plusieurs users → même opérateur**, chacun son `login_siren` (GEN-473 Cas#4), **pas** 1 user → plusieurs opérateurs.
+
+## 3. État du code (points d'ancrage)
+
+- **User** : `auth.users` — scopé `operator_id` **XOR** `territory_id`, **sans FK ni CHECK** (integers nus). Pas de colonne SIRET. Dérivé au login dans `auth/providers/UserRepository.ts` (`authenticateByEmail`).
+- **Gate ProConnect** : `auth/providers/ProConnectOIDCProvider.ts:140-153` → `failsSirenCheck()` (fail-closed *par accident* via `String(null)`) ; `registry.admin` bypass.
+- **Seam session→contexte** : `proxy/HttpTransport.ts:377-389` injecte `session.user` en `call.user` par requête ; `getTerritoryInfos()` (`:482-505`) recalcule `authorizedZoneCodes` — **résolution géo, PAS revalidation d'appartenance**.
+- **Auth de session** : `authGuard.ts` = **no-op sur le chemin cookie** (n'agit que si header `authorization`). `/auth/me` (`AuthRouter.ts:95`) rejette 401 lui-même si pas de session. Callback `AuthRouter.ts:48-52` pose `session.user` **sans `regenerate()`**.
+- **CRUD user** : `dashboard/providers/UsersRepository.ts:100-165` — écrit `role`/`operator_id`/`territory_id` **sans contrôle de rôle cible ni de champ** ; gaté seulement scope-local (`HasPermissionByScopeMiddleware` teste `params.territory_id === call.user.territory_id`).
+- **Précédents réutilisables** : pattern `authorizedZoneCodes`, `territory_group_selector` (pivot many-per-entity), scoping en tableau (`ExportParams.operator_id: number[]`, `= ANY(...)`).
+
+### Blast radius de `auth.users.{operator_id,territory_id}`
+
+- **Cat A — lectures colonne SQL** (à migrer) : seam login (`auth/providers/UserRepository.ts`) + `dashboard/providers/UsersRepository.ts` (filtres list/delete, projection, LEFT JOIN recherche).
+- **Cat B — lectures objet session `call.user.*`** (SÛRES, suivent la bascule) : **tout l'aval** (export/policy/territoire/opérateur/credentials + tous les middlewares de scope). Aucun changement.
+- **Cat C — écritures** : `dashboard/providers/UsersRepository.ts` create/update.
+- **Non concerné** : `accessTokenMiddleware.ts` (chemin machine Dex) — `operator_id` du token, pas de `auth.users`.
+
+**Migration code réelle = 2 fichiers** : seam login + `UsersRepository` dashboard.
+
+## 4. Modèle de données cible
+
+```sql
+CREATE EXTENSION IF NOT EXISTS btree_gist;   -- pour la contrainte d'homogénéité
+
+CREATE TABLE auth.user_scopes (
+  _id          serial PRIMARY KEY,
+  user_id      int  NOT NULL REFERENCES auth.users(_id) ON DELETE CASCADE,
+  operator_id  int  NULL REFERENCES operator.operators(_id),
+  territory_id int  NULL REFERENCES territory.territory_group(_id),
+  is_default   boolean NOT NULL DEFAULT false,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  scope_type   text GENERATED ALWAYS AS
+                 (CASE WHEN operator_id IS NOT NULL THEN 'o' ELSE 't' END) STORED,
+  CHECK (num_nonnulls(operator_id, territory_id) = 1)                 -- XOR par ligne
+);
+
+-- unicité / cardinalité métier
+CREATE UNIQUE INDEX user_scopes_territory_key       ON auth.user_scopes(user_id, territory_id) WHERE territory_id IS NOT NULL;
+CREATE UNIQUE INDEX user_scopes_single_operator_key ON auth.user_scopes(user_id)               WHERE operator_id  IS NOT NULL; -- opérateur 1:1 (subsume le dédoublonnage op)
+CREATE UNIQUE INDEX user_scopes_one_default_key     ON auth.user_scopes(user_id)               WHERE is_default;             -- ≤ 1 défaut / user
+
+-- homogénéité XOR par user (v2, non-optionnelle) : interdit op + territoire sur un même user
+ALTER TABLE auth.user_scopes
+  ADD CONSTRAINT user_scopes_homogeneous_excl EXCLUDE USING gist (user_id WITH =, scope_type WITH <>);
+
+-- lookup inverse (liste dashboard filtrée par operator_id / territory_id)
+CREATE INDEX user_scopes_operator_idx  ON auth.user_scopes(operator_id)  WHERE operator_id  IS NOT NULL;
+CREATE INDEX user_scopes_territory_idx ON auth.user_scopes(territory_id) WHERE territory_id IS NOT NULL;
+```
+
+- `auth.user_scopes` = **source de vérité unique** des périmètres autorisés (défaut inclus via `is_default`).
+- `auth.users.{operator_id, territory_id}` → **dépréciées** : conservées + **dual-writées** pendant la transition (cf. §8), droppées en PR de suivi.
+- `auth.users.login_siren varchar(9)` — **gate ProConnect uniquement**, découplé des périmètres.
+- **Index redondant retiré** (`user_scopes_single_operator_key` subsume le couple op). **Nommage `*_key`/`*_idx`** conforme au schéma existant (pas de `ux_`).
+- `ON DELETE CASCADE` sur `user_id` ; **NO ACTION** sur operator/territory → supprimer un territoire référencé est **bloqué** (RESTRICT) : nouveau couplage, les flux de hard-delete territoire/opérateur devront purger `user_scopes` d'abord.
+- **Territoires custom** (GEN-473) : `territory_group` sans company/SIRET, pointé via `territory_id` comme un territoire classique.
+
+## 5. Auth & ProConnect (le seam)
+
+- `failsSirenCheck` : compare **SIREN(ProConnect) vs `auth.users.login_siren`**. `registry.admin` bypass.
+  **Fail-closed explicite (v2)** : pour tout rôle **non-admin**, `login_siren` NULL/vide ⇒ **échec** du gate (jamais bypass). Ne pas dépendre de `String(null)`. Test dédié.
+- `authenticateByEmail` réécrit : (1) match email ; (2) renvoie `login_siren` (gate) ; (3) charge le scope **par défaut** (`user_scopes WHERE is_default`) → seed `session.user.operator_id/territory_id` + libellé/SIRET d'affichage. **Fallback (v2)** : si aucun `is_default`, prendre `MIN(_id)` (login jamais cassé) ; (4) charge la **liste** des scopes → `session.user.scopes[]` (dropdown).
+- `UserInterface` (session) gagne `scopes: Array<{ operator_id?, territory_id?, label, siret? }>` ; garde `operator_id/territory_id` = scope actif.
+- **Anti-fixation (v2)** : au callback, `req.session.regenerate()` **avant** d'attacher `user`, puis `save()`.
+- Chemin machine (Dex) inchangé.
+
+## 6. Bascule de contexte (users territoire) — durcie
+
+**Route `POST /auth/context` `{ territory_id }`** dans `AuthRouter` :
+1. **401 si `!req.session?.user`** (ne pas se reposer sur `authGuard`, no-op sur cookie).
+2. **Refuser** si l'user est de type opérateur (règle §2 : seul le type territoire bascule).
+3. **Revalidation DB (v2, C1/E1)** : `SELECT 1 FROM auth.user_scopes WHERE user_id = <session user> AND territory_id = <body.territory_id>` — **matcher strictement sur le champ `territory_id`** (jamais « le nombre est dans mes scopes » → IDOR par collision op/territoire). 403 si absent. La liste `session.scopes[]` ne sert **qu'à peindre l'UI**, jamais à autoriser.
+4. **Réécrire tout le tuple (v2, M3)** : `session.user.territory_id = territory_id` **et** `session.user.operator_id = null` ; `req.session.save()`.
+5. Réponse : le **contexte actif** (id + libellé) — renvoyé aussi dans les réponses d'actions conséquentes pour réconciliation front.
+
+**Sécurité du modèle de session (v2)** — on garde la **session serveur comme vérité enforced** (Catégorie B gratuite) mais on la durcit :
+- **Revalidation DB à chaque switch** (ci-dessus) — la bascule ne fait jamais confiance au cache session.
+- **Purge des sessions à la révocation** (C1/F1) : au retrait d'un scope ou changement de rôle d'un user, invalider ses sessions Redis (index sessions par `user_id`). Sinon un scope retiré reste accessible tant que le cookie vit sur le scope *actif* courant.
+- **`maxAge` de session raccourci** pour borner l'exposition résiduelle.
+- **Attention `authorizedZoneCodes`** : `getTerritoryInfos` recalcule la **géo**, pas le **droit** — ce n'est pas une revalidation d'appartenance. La revalidation vient du switch (DB) + de la purge à la révocation.
+
+**Défaut & reload** : login frais → `is_default`. Session Redis conserve le scope basculé (survit au reload). Miroir client (sessionStorage) = **affichage** ; sur `focus`/`visibilitychange`, re-GET du contexte serveur + reconcilie. **Ne jamais** traiter le miroir client comme source de vérité (confused-deputy multi-onglets — le serveur enforce, mais l'UI ne doit pas mentir).
+
+## 7. Gestion des utilisateurs (dashboard) — gate au niveau action
+
+Fichier central : `dashboard/providers/UsersRepository.ts` + actions.
+
+**Autorisation (v2, C2/E4) — le point le plus sensible :**
+- Les **champs/opérations privilégiés** (`login_siren`, octroi/retrait de scope multi-territoire) passent par des **actions dédiées gatées par une permission détenue seulement par `registry.admin`** (ex. `registry.user.manageScopes`), vérifiée **au niveau action** (pas l'écran). Un middleware rejette la présence de ces champs si le caller n'a pas la permission.
+- **Garde de hiérarchie de rôle (v2)** : createUser/updateUser refusent d'attribuer un `role` de rang ≥ celui du caller (un `territory.admin` **ne peut pas** créer/promouvoir un `registry.*`). Corrige un **trou pré-existant** que le découplage `login_siren` armerait.
+
+**CRUD :**
+- **Lister les users d'un groupe** : `JOIN auth.user_scopes us … WHERE us.operator_id = X / us.territory_id = ANY(<scopes admin>)`, avec **`DISTINCT`/`GROUP BY users._id`** (un user multi-territoires apparaît sinon N fois).
+- **Créer** : INSERT `auth.users` (**+ dual-write `operator_id/territory_id` pendant l'expand**, cf. §8) + INSERT `user_scopes` (`is_default=true`) + `login_siren` saisi par un `registry.admin`.
+- **Gérer les scopes** : ajout/retrait de territoires. **Retrait du défaut ⇒ promotion auto** d'un autre scope (v2, I2) ; **interdire** de vider tous les scopes (user orphelin = login cassé). Ajout d'un 2ᵉ opérateur → refus métier propre (avant la contrainte DB).
+- **Supprimer** : scoping via jointure pivot. `ON DELETE CASCADE` nettoie `user_scopes` ; **purger aussi les sessions Redis** (cf. §6).
+
+**UX (v2, revue UX) :**
+- **Bascule (header)** : **combobox recherchable** (pas `<select>` natif — dizaines de territoires possibles), affiche le **nom** (corriger `ProfilButton` qui montre l'ID brut) + coche l'actif. 1 seul scope → **badge statique**, pas de menu. **Rappel du périmètre actif au point d'action** (modale de confirmation d'export/campagne), pas seulement le header. Feedback au switch : invalidation données + toast `success` + `aria-live` (RGAA) + confirmation si saisie en cours.
+- **Formulaire user** : sortir de la modale saturée → **page dédiée** ou **`fieldset` DSFR** segmentés (Identité / Connexion / Périmètres). CRUD scopes = **`Table` + radio "défaut" + `Autocomplete` d'ajout**.
+- **`login_siren`** : `label="SIREN de connexion (ProConnect)"`, `hint="9 chiffres — distinct du SIRET du territoire"`, validation `/^\d{9}$/`, `inputMode=numeric`, **pré-remplissage** suggéré `LEFT(siret_territoire, 9)` modifiable.
+- **Mono-opérateur** : pour un user opérateur, **pas d'affordance d'ajout** (un seul `Select`, 1:1).
+- **Gating** : un `territory.admin` → section Périmètres + `login_siren` **masquées** (pas grisées).
+- **États limites** : user sans territoire (`registry.admin` → libellé « Administration RPC »), retrait du défaut, bascule vers scope révoqué → 403 + toast + refresh liste.
+
+## 8. Migration & backfill (expand / contract, défensif)
+
+**Audit préalable OBLIGATOIRE (v2, C3)** — `auth.users` n'a jamais eu FK/CHECK :
+```sql
+SELECT count(*) FROM auth.users WHERE operator_id IS NOT NULL AND territory_id IS NOT NULL;      -- both-set
+SELECT count(*) FROM auth.users u WHERE u.operator_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM operator.operators o WHERE o._id = u.operator_id);               -- orphelins op
+SELECT count(*) FROM auth.users u WHERE u.territory_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM territory.territory_group g WHERE g._id = u.territory_id);        -- orphelins territoire
+```
+Décider explicitement du sort des both-set/orphelins (nettoyer avant, ou exclure sciemment).
+
+**PR « expand »** :
+1. `CREATE EXTENSION btree_gist` + `CREATE TABLE auth.user_scopes` + contraintes/index (§4). Index/CHECK **avant** le backfill (échoue vite sur données sales).
+2. `ALTER TABLE auth.users ADD COLUMN login_siren varchar(9)`.
+3. **Backfill défensif en 2 INSERT idempotents** :
+   ```sql
+   INSERT INTO auth.user_scopes (user_id, operator_id, is_default)
+   SELECT u._id, u.operator_id, true FROM auth.users u
+   WHERE u.operator_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+
+   INSERT INTO auth.user_scopes (user_id, territory_id, is_default)
+   SELECT u._id, u.territory_id, true FROM auth.users u
+   WHERE u.territory_id IS NOT NULL AND u.operator_id IS NULL
+     AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+   ```
+4. **Backfill `login_siren`** = `LEFT(COALESCE(o.siret, c.siret), 9)` via **LEFT JOIN** operator / territory_group→company (ne pas dropper les users sans company). `siret` mal formé → surveiller.
+5. **Bascule code + dual-write (v2, I3)** : le nouveau code **lit** `user_scopes` mais **continue d'écrire** `auth.users.operator_id/territory_id` (dual-write) tant que le contract n'a pas confirmé qu'aucun pod ne les lit. Évite l'invisibilité inter-pods pendant le rolling update.
+6. **Contrôles post-migration BLOQUANTS (gate de déploiement, pas advisory)** : chaque user non-admin a **exactement 1** `is_default` ; `login_siren` peuplé partout où un SIRET existe ; 0 both-set/orphelin résiduel.
+
+**PR « contract »** : retirer le dual-write, puis `DROP COLUMN auth.users.operator_id, territory_id` une fois qu'aucun code ne les lit (grep) et le déploiement stabilisé.
+
+*(Migrations jouées au déploiement k8s ; expand/contract + dual-write évitent tout couplage migration↔rollback et l'invisibilité inter-pods.)*
+
+## 9. Tests (TDD)
+
+- **Unit** :
+  - `failsSirenCheck` : match / mismatch / bypass admin / **`login_siren` NULL ∧ non-admin ⇒ échec** (fail-closed).
+  - Contraintes pivot : refus 2ᵉ opérateur, multi-territoires OK, unicité `is_default`, **homogénéité (op+territoire refusé)**.
+  - `/auth/context` : 403 hors liste, **403 sur collision op/territoire** (`operator_id:42` ⇏ `territory_id:42`), **401 sans session**, refus si user opérateur, mutation tuple complet.
+- **Intégration (DB)** :
+  - `UsersRepository` list/create/delete via jointure pivot (+ `DISTINCT` multi-territoires) ; `authenticateByEmail` seed défaut + fallback `MIN(_id)` + `scopes[]` + `login_siren`.
+  - **Escalade** : `territory.admin` → **403** sur saisie `login_siren` / octroi de scope / attribution `role: registry.*`.
+  - **Révocation** : retrait de scope → sessions Redis de l'user purgées → accès coupé.
+- **e2e (stack)** : login → `/auth/context` (switch) → export scopé au **nouveau** territoire + résolution territoire correcte → ferme les TODO ticket « filtrage exports » et « résolution territoire ».
+- **Backfill** : correction/idempotence sur données seed (dont both-set/orphelins).
+
+## 10. Évaluation risque & difficulté (v2)
+
+| Volet | Difficulté | Risque | Note |
+|-------|-----------|--------|------|
+| Modèle `user_scopes` + contraintes | Faible | Faible | Contraintes DB portent le métier + homogénéité |
+| Seam login + `failsSirenCheck` fail-closed | Moyenne | Moyen | Chemin critique ; tests fail-closed obligatoires |
+| Bascule `/auth/context` durcie | Moyenne | Moyen | Revalidation DB + typage strict + 401/refus opérateur |
+| **Durcissement auth (C1/C2)** | Moyenne | **Élevé si omis** | Purge session, gate champ privilégié, hiérarchie de rôle — **bloquants sécurité** |
+| Aval (exports, campagnes, scoping) | Nulle | Faible | Catégorie B suit la session |
+| CRUD dashboard + UX | Moyenne-Haute | Moyen | Page/fieldset, table scopes, gating action |
+| Migration/backfill défensif | Moyenne | Moyen | Audit + 2 INSERT idempotents + dual-write + contrôles bloquants |
+| Front (combobox, rappel périmètre) | Moyenne | Faible | Réutilise `Autocomplete`/patterns DSFR |
+
+**Risques résiduels** : (1) révocation vs sessions actives → mitigé par purge Redis ; (2) escalade `registry.admin` → mitigé par gate action + hiérarchie de rôle ; (3) cohérence backfill → mitigé par audit + contrôles bloquants.
+
+## 11. Hors-scope (évolutions futures)
+
+- Périmètre **agrégé/simultané** (export « tous mes territoires ») — jointures `territory_id` en tableau.
+- **Comptes hétérogènes** (opérateur + territoire) avec rôle par membership.
+- **Délégation inter-orgs** + **self-service ProConnect** (alias SIRET même domaine).
+- **Multi-SIRET de connexion pour un même user** (alias ProConnect sur un email) — V1 = un `login_siren`/user.
+- Modèle **URL-par-onglet** pour le contexte (retenu : session serveur durcie en V1).
+- Convergence avec le mode `simulate` admin existant (deux « je change de contexte » à unifier).
+
+## 12. Trace des revues expertes (2026-07-18)
+
+- **BDD** : backfill défensif (both-set/orphelins, 2 INSERT idempotents), index redondant retiré, dual-write expand, index lookup inverse, `DISTINCT`, exclusion constraint homogénéité, nommage `*_idx/*_key`, promotion défaut au retrait.
+- **Sécurité (OWASP)** : **C1** revalidation DB de la bascule + purge session à la révocation (le recalcul par-requête ne revérifie pas l'appartenance) ; **C2** gate des champs privilégiés + hiérarchie de rôle (sinon élévation `registry.admin` via createUser) ; `/auth/context` typé + 401 anonyme + refus opérateur ; fail-closed `login_siren` NULL ; `regenerate` anti-fixation ; réécriture tuple complet à la bascule.
+- **UX (DSFR)** : combobox recherchable + noms, rappel périmètre au point d'action, page/`fieldset`, table+radio+Autocomplete pour les scopes, `login_siren` étiqueté/validé/pré-rempli, mono-opérateur sans affordance, gating = masquer, états limites.


### PR DESCRIPTION
## Contexte

Première tranche du chantier **multi-SIRET / multi-périmètre** (GEN-686) : permettre à un compte territoire de porter plusieurs périmètres et de découpler le SIRET de connexion (gate ProConnect) des périmètres autorisés.

Cette PR pose **la fondation données**. Elle est la base d'un *merge train* :

```
T1 (cette PR)  ->  T2 (auth) || T4 (dashboard)  ->  T3 (/auth/context)  ->  T5 (front)  ->  T6 (drop colonnes)
```

Spec et plan détaillés inclus (`docs/superpowers/`).

## Contenu

- **Table pivot `auth.user_scopes`** = source de vérité des périmètres autorisés (défaut porté par `is_default`).
  - `CHECK` XOR par ligne, opérateur **1:1** (`user_scopes_single_operator_key`), **<=1 défaut** (`user_scopes_one_default_key`), **homogénéité** op/territoire par user (exclusion `btree_gist`), index de lookup inverse.
- **Colonne `auth.users.login_siren varchar(9)`** — gate ProConnect uniquement, découplée des périmètres (consommée en T2).
- **Backfill idempotent** en 2 INSERT (opérateur prioritaire sur d'éventuels both-set) + backfill `login_siren`.
- **`UserScopeRepository`** : `findByUser`, `findDefault` (fallback `MIN(_id)`), `userHasTerritory` (match **strict** `territory_id` — anti-IDOR), `addTerritory`, `removeTerritory` (promotion du défaut, refus du dernier scope), `setOperator`.

## Sûreté du backfill

Un audit en lecture seule de la base confirme l'absence de lignes *both-set* (operator ET territory renseignés) et d'orphelins operator/territoire ; les comptes sans périmètre sont exclusivement des comptes d'administration RPC (`login_siren` NULL, couvert par le bypass `registry.admin`). La migration ne peut donc pas échouer sur des données incohérentes.

## Validation

- `deno lint` OK sur les fichiers ajoutés.
- Migration validée **end-to-end contre un Postgres 15 réel** (contraintes, backfill, idempotence, promotion de défaut).
- La spec d'intégration Deno n'a pas pu être exécutée en local (stack Docker) -> **à valider par le job CI `(api) integration tests`**.

## Hors-scope (tranches suivantes)

Seam de login, `failsSirenCheck` fail-closed, route `/auth/context`, CRUD dashboard gaté et front arrivent en T2-T5. Les colonnes `auth.users.operator_id/territory_id` restent en place (dual-write en T4, drop en T6).
