### PR TITLE
feat(auth): découple le SIRET de connexion des périmètres (GEN-686) [T2/6]

### DIFF
--- a/api/src/pdc/proxy/types/UserInterface.ts
+++ b/api/src/pdc/proxy/types/UserInterface.ts
@@ -1,3 +1,5 @@
+import { UserScope } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
+
 export interface UserInterface {
   email: string;
   firstname: string;
@@ -5,8 +7,9 @@ export interface UserInterface {
   phone?: string;
   group?: string; // computed prop
   role: string;
-  operator_id?: number;
-  territory_id?: number;
+  operator_id?: number; // = scope actif (inchangé pour la Cat. B)
+  territory_id?: number; // = scope actif
+  scopes: UserScope[]; // périmètres autorisés (peindre l'UI)
   _id: number;
   permissions: string[];
   status: string;

--- a/api/src/pdc/services/auth/AuthRouter.ts
+++ b/api/src/pdc/services/auth/AuthRouter.ts
@@ -40,15 +40,22 @@ export class AuthRouter {
         const { state, nonce } = req.session?.auth || {};
 
         // Fetch tokens and user info from ProConnect OIDC Provider
+        // (état OIDC state/nonce lu ci-dessus, avant la régénération de session)
         const tokens = await this.proConnectOIDCProvider.getToken(url, nonce, state);
         const claims = tokens.claims();
         const user = await this.proConnectOIDCProvider.getUserInfo(tokens.access_token, claims!.sub);
 
-        // Store user and token information in the session
-        req.session = req.session || {};
-        req.session.auth = {};
-        req.session.auth.id_token = tokens.id_token;
+        // Anti-fixation : régénère la session avant d'attacher l'utilisateur authentifié.
+        await new Promise<void>((resolve, reject) =>
+          req.session.regenerate((err: Error) => err ? reject(err) : resolve())
+        );
+
+        // Store user and token information in the fresh session
+        req.session.auth = { id_token: tokens.id_token };
         req.session.user = user;
+        await new Promise<void>((resolve, reject) =>
+          req.session.save((err: Error) => err ? reject(err) : resolve())
+        );
 
         return res.redirect(this.config.get("app_url"));
       }),

--- a/api/src/pdc/services/auth/AuthServiceProvider.ts
+++ b/api/src/pdc/services/auth/AuthServiceProvider.ts
@@ -12,10 +12,12 @@ import { DexOIDCProvider } from "./providers/DexOIDCProvider.ts";
 import { OperatorRepository } from "./providers/OperatorRepository.ts";
 import { ProConnectOIDCProvider } from "./providers/ProConnectOIDCProvider.ts";
 import { UserRepository } from "./providers/UserRepository.ts";
+import { UserScopeRepository } from "./providers/UserScopeRepository.ts";
 
 @serviceProvider({
   config,
   providers: [
+    UserScopeRepository,
     UserRepository,
     OperatorRepository,
     DexOIDCProvider,

--- a/api/src/pdc/services/auth/providers/ProConnectOIDCProvider.ts
+++ b/api/src/pdc/services/auth/providers/ProConnectOIDCProvider.ts
@@ -1,9 +1,20 @@
 import { ConfigInterfaceResolver, InitHookInterface, provider } from "@/ilos/common/index.ts";
 import { logger } from "@/lib/logger/index.ts";
-import { LocalSiretUser, UserRepository } from "@/pdc/services/auth/providers/UserRepository.ts";
+import { UserRepository } from "@/pdc/services/auth/providers/UserRepository.ts";
 import { createRemoteJWKSet } from "dep:jose";
 import * as client from "dep:openid-client";
 import { getPermissions } from "../config/permissions.ts";
+
+// Gate ProConnect fail-closed : SIREN(ProConnect) doit égaler login_siren (registry.admin bypass).
+export function failsSirenCheck(
+  proconnect: { siren: string },
+  user: { login_siren?: string | null; role: string },
+): boolean {
+  if (user.role === "registry.admin") return false; // admin : bypass du gate
+  const loginSiren = user.login_siren?.trim();
+  if (!loginSiren) return true; // fail-closed explicite : pas de SIREN de connexion, jamais de String(null)
+  return proconnect.siren.substring(0, 9) !== loginSiren;
+}
 
 @provider()
 export class ProConnectOIDCProvider implements InitHookInterface {
@@ -104,7 +115,9 @@ export class ProConnectOIDCProvider implements InitHookInterface {
       const user = await this.userRepository.authenticateByEmail(email);
 
       if (!user) throw new Error(`User not found: ${email}`);
-      if (this.failsSirenCheck(user, siret)) throw new Error(`SIRET check failed: ${email} / ${siret}`);
+      if (failsSirenCheck({ siren: siret.substring(0, 9) }, user)) {
+        throw new Error(`SIRET check failed: ${email} / ${siret}`);
+      }
 
       return {
         ...user,
@@ -135,20 +148,5 @@ export class ProConnectOIDCProvider implements InitHookInterface {
       state,
     });
     return { state, redirectUrl };
-  }
-
-  private failsSirenCheck(user: LocalSiretUser, siret: string): boolean {
-    // admins bypass siret check
-    if (user.role === "registry.admin") return false;
-
-    const siren = siret.substring(0, 9);
-    const userSiren = String(user.siret).substring(0, 9);
-    const fails = siren !== userSiren;
-
-    if (fails) {
-      console.warn(`[ProConnectOIDCProvider] SIRET mismatch for user: expected SIREN ${siren}, got ${userSiren}`);
-    }
-
-    return fails;
   }
 }

--- a/api/src/pdc/services/auth/providers/ProConnectOIDCProvider.unit.spec.ts
+++ b/api/src/pdc/services/auth/providers/ProConnectOIDCProvider.unit.spec.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import { failsSirenCheck } from "./ProConnectOIDCProvider.ts";
+
+describe("ProConnectOIDCProvider.failsSirenCheck", () => {
+  it("fails closed when login_siren is null and user is not registry.admin", () => {
+    assertEquals(failsSirenCheck({ siren: "123456789" }, { login_siren: null, role: "territory.admin" }), true);
+  });
+
+  it("fails closed when login_siren is empty and user is not registry.admin", () => {
+    assertEquals(failsSirenCheck({ siren: "123456789" }, { login_siren: "", role: "territory.admin" }), true);
+  });
+
+  it("passes for registry.admin regardless of siren", () => {
+    assertEquals(failsSirenCheck({ siren: "999999999" }, { login_siren: null, role: "registry.admin" }), false);
+  });
+
+  it("passes when proconnect siren matches login_siren", () => {
+    assertEquals(failsSirenCheck({ siren: "123456789" }, { login_siren: "123456789", role: "territory.admin" }), false);
+  });
+
+  it("fails when proconnect siren differs from login_siren", () => {
+    assertEquals(failsSirenCheck({ siren: "123456789" }, { login_siren: "987654321", role: "territory.admin" }), true);
+  });
+});

--- a/api/src/pdc/services/auth/providers/UserRepository.integration.spec.ts
+++ b/api/src/pdc/services/auth/providers/UserRepository.integration.spec.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+
+import sql from "@/lib/pg/sql.ts";
+import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/dbMacro.ts";
+
+import { UserRepository } from "./UserRepository.ts";
+import { UserScopeRepository } from "./UserScopeRepository.ts";
+
+describe("UserRepository.authenticateByEmail", () => {
+  let db: DenoDbContext;
+  let repository: UserRepository;
+  let scopes: UserScopeRepository;
+  const { before, after } = makeDenoDbBeforeAfter();
+  let seq = 0;
+
+  // Crée un territory_group rattaché à la company seed (dinum, _id=1).
+  async function ensureTerritory(id: number): Promise<void> {
+    await db.connection.query(sql`
+      INSERT INTO territory.territory_group (_id, company_id, name)
+      VALUES (${id}::int, 1::int, ${`Test territoire ${id}`}::varchar)
+      ON CONFLICT DO NOTHING
+    `);
+  }
+
+  // Crée un utilisateur nu (sans scope) avec un login_siren donné et renvoie {id, email}.
+  async function createUser(loginSiren: string | null): Promise<{ id: number; email: string }> {
+    const email = `auth-by-email-${++seq}@example.com`;
+    const rows = await db.connection.query<{ _id: number }>(sql`
+      INSERT INTO auth.users (email, firstname, lastname, password, status, role, login_siren)
+      VALUES (${email}::varchar, 'U'::varchar, 'Auth'::varchar, 'x'::varchar, 'active'::auth.user_status_enum, 'territory.admin'::varchar, ${loginSiren}::varchar)
+      RETURNING _id
+    `);
+    return { id: rows[0]._id, email };
+  }
+
+  beforeAll(async () => {
+    db = await before();
+    scopes = new UserScopeRepository(db.connection);
+    repository = new UserRepository(db.connection, scopes);
+  });
+
+  afterAll(async () => {
+    await after(db);
+  });
+
+  it("returns login_siren and seeds the active scope from the default territory", async () => {
+    const { id, email } = await createUser("123456789");
+    await ensureTerritory(300);
+    await ensureTerritory(301);
+    await scopes.addTerritory(id, 300, true);
+    await scopes.addTerritory(id, 301, false);
+
+    const user = await repository.authenticateByEmail(email);
+
+    assertEquals(user?.login_siren, "123456789");
+    assertEquals(user?.territory_id, 300);
+    assertEquals(user?.operator_id, null);
+    assertEquals(user?.scopes.length, 2);
+    // défaut en tête (is_default DESC)
+    assertEquals(user?.scopes[0].territory_id, 300);
+  });
+
+  it("falls back to MIN(_id) scope when no default is flagged", async () => {
+    const { id, email } = await createUser(null);
+    await ensureTerritory(302);
+    await ensureTerritory(303);
+    await scopes.addTerritory(id, 302, false);
+    await scopes.addTerritory(id, 303, false);
+
+    const user = await repository.authenticateByEmail(email);
+
+    assertEquals(user?.login_siren, null);
+    assertEquals(user?.territory_id, 302); // MIN(_id) = premier inséré
+    assertEquals(user?.scopes.length, 2);
+  });
+
+  it("returns null for an unknown email", async () => {
+    assertEquals(await repository.authenticateByEmail("does-not-exist@example.com"), null);
+  });
+});

--- a/api/src/pdc/services/auth/providers/UserRepository.reset-marker.integration.spec.ts
+++ b/api/src/pdc/services/auth/providers/UserRepository.reset-marker.integration.spec.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
 import sql from "@/lib/pg/sql.ts";
 import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/index.ts";
 import { UserRepository } from "./UserRepository.ts";
+import { UserScopeRepository } from "./UserScopeRepository.ts";
 
 describe("UserRepository reset deletion marker on login", () => {
   let db: DenoDbContext;
@@ -11,7 +12,7 @@ describe("UserRepository reset deletion marker on login", () => {
 
   beforeAll(async () => {
     db = await before();
-    repository = new UserRepository(db.connection);
+    repository = new UserRepository(db.connection, new UserScopeRepository(db.connection));
     await db.connection.query(
       sql`INSERT INTO auth.users (email, firstname, lastname, role, last_login_at, deletion_warned_at)
       VALUES ('login@reset.test', 'L', 'L', 'operator.user', now() - '13 months'::interval, now() - '2 days'::interval)`,

--- a/api/src/pdc/services/auth/providers/UserRepository.ts
+++ b/api/src/pdc/services/auth/providers/UserRepository.ts
@@ -1,50 +1,55 @@
 import { provider } from "@/ilos/common/index.ts";
 import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import sql, { fromObject, raw, RawValue } from "@/lib/pg/sql.ts";
+import { UserScope, UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
 
 export type LocalSiretUser = {
   email: string;
   role: string;
+  login_siren: string | null;
   operator_id: number | null;
   territory_id: number | null;
   siret: string | null;
   _id: number;
   analytics_id: string;
   organisation: string | null;
+  scopes: UserScope[];
+};
+
+// Identité de base lue sur auth.users ; les périmètres viennent de user_scopes.
+type UserIdentityRow = {
+  email: string;
+  role: string;
+  login_siren: string | null;
+  _id: number;
+  analytics_id: string;
 };
 
 @provider()
 export class UserRepository {
   public readonly table = "auth.users";
-  public readonly territoryTable = "territory.territory_group";
-  public readonly operatorTable = "operator.operators";
-  public readonly companyTable = "company.companies";
 
-  constructor(protected denoConnection: DenoPostgresConnection) {}
+  constructor(
+    protected denoConnection: DenoPostgresConnection,
+    protected userScopeRepository: UserScopeRepository,
+  ) {}
 
   async authenticateByEmail(email: string, data: Record<string, RawValue> = {}): Promise<LocalSiretUser | null> {
     if (!email) return null;
-    const rows = await this.denoConnection.query<LocalSiretUser>(sql`
+    const rows = await this.denoConnection.query<UserIdentityRow>(sql`
       SELECT
         u.email,
         u.role,
-        u.operator_id,
-        u.territory_id,
-        COALESCE(o.siret, c.siret) as siret,
+        u.login_siren,
         u._id,
-        u.analytics_id,
-        COALESCE(o.name, t.name) as organisation
+        u.analytics_id
       FROM ${raw(this.table)} u
-      LEFT JOIN ${raw(this.territoryTable)} t
-        ON t._id = u.territory_id
-      LEFT JOIN ${raw(this.companyTable)} c on c._id = t.company_id
-      LEFT JOIN ${raw(this.operatorTable)} o
-        ON o._id = u.operator_id
       WHERE lower(u.email) = ${email.trim().toLowerCase()}
       LIMIT 1
     `);
 
     if (!rows.length) return null;
+    const identity = rows[0];
 
     // Update last_login_at and other data if provided
     const fields = fromObject({ ...data, last_login_at: "NOW()", deletion_warned_at: raw("NULL") });
@@ -54,6 +59,26 @@ export class UserRepository {
       WHERE email = ${email}
     `);
 
-    return rows[0];
+    // Périmètres : liste complète (dropdown) + défaut (contexte actif), fallback MIN(_id) porté par le repo.
+    const scopes = await this.userScopeRepository.findByUser(identity._id);
+    const def = await this.userScopeRepository.findDefault(identity._id);
+    const active = scopes.find((s) =>
+      def?.operator_id != null
+        ? s.operator_id === def.operator_id
+        : def?.territory_id != null && s.territory_id === def.territory_id
+    ) ?? scopes[0];
+
+    return {
+      email: identity.email,
+      role: identity.role,
+      login_siren: identity.login_siren,
+      _id: identity._id,
+      analytics_id: identity.analytics_id,
+      operator_id: def?.operator_id ?? null,
+      territory_id: def?.territory_id ?? null,
+      siret: active?.siret ?? null,
+      organisation: active?.label ?? null,
+      scopes,
+    };
   }
 }


### PR DESCRIPTION
## Contexte

Tranche **T2** du chantier multi-SIRET/multi-périmètre (GEN-686). Stackée sur T1 (#3318).
Base de la PR = `feat/gen686-t1-user-scopes` (se retargetera sur `main` au merge de T1).

## Contenu — découplage du SIRET de connexion

- **`failsSirenCheck`** extrait en fonction pure et rendu **fail-closed explicite** : `registry.admin` bypass ; sinon `login_siren` NULL/vide ⇒ **échec** du gate (jamais de bypass), sinon comparaison stricte du SIREN ProConnect. Ne dépend plus d'un `String(null)`.
- **`authenticateByEmail`** : charge le scope **par défaut** (`is_default`, fallback `MIN(_id)` ⇒ login jamais cassé) pour seeder le contexte actif, et la **liste** `scopes[]` (via `UserScopeRepository`) pour le futur sélecteur ; renvoie `login_siren` pour le gate. Le SIRET/libellé d'affichage provient désormais du scope actif, plus des JOIN inline.
- **`UserInterface`** : ajout de `scopes: UserScope[]` ; `operator_id`/`territory_id` restent le **scope actif** (aval Catégorie B inchangé).
- **`AuthRouter`** : `req.session.regenerate()` au callback **avant** d'attacher l'utilisateur (anti-fixation de session), état OIDC (`state`/`nonce`) lu avant.
- Enregistrement de `UserScopeRepository` dans `AuthServiceProvider`.

## Tests

- Unit : `failsSirenCheck` (match / mismatch / bypass admin / **login_siren NULL non-admin ⇒ échec**) — 5 cas verts en local.
- Intégration : `authenticateByEmail` (seed défaut, fallback, `scopes[]`, `login_siren`) — à valider en CI.
