### PR TITLE
feat(dashboard): CRUD user multi-périmètre gaté registry.admin (GEN-686) [T4/6]

### DIFF
--- a/api/src/pdc/proxy/middlewares/sessionMiddleware.ts
+++ b/api/src/pdc/proxy/middlewares/sessionMiddleware.ts
@@ -5,6 +5,9 @@ import { NextFunction, Request, Response } from "dep:express";
 import expressSession from "dep:express-session";
 import { Redis } from "dep:redis";
 
+// Préfixe des clés de session dans Redis (connect-redis). Source unique partagée avec SessionRepository.
+export const SESSION_KEY_PREFIX = "proxy:";
+
 export function sessionMiddleware(kernel: KernelInterface) {
   const config = kernel.get(ConfigInterfaceResolver);
   const sessionSecret = config.get("proxy.session.secret");
@@ -26,7 +29,7 @@ export function sessionMiddleware(kernel: KernelInterface) {
     secret: sessionSecret,
     resave: false,
     saveUninitialized: false,
-    store: new RedisStore({ client: redis, prefix: "proxy:" }),
+    store: new RedisStore({ client: redis, prefix: SESSION_KEY_PREFIX }),
   });
 
   return (req: Request, res: Response, next: NextFunction) => {

--- a/api/src/pdc/services/auth/config/permissions.ts
+++ b/api/src/pdc/services/auth/config/permissions.ts
@@ -129,6 +129,9 @@ const permissions = {
   ],
   "user.sendEmail": ["operator.admin", "territory.admin", "registry.admin"],
 
+  // Champs/opérations privilégiés (login_siren, octroi de scope multi-territoire) : registry.admin seul.
+  "user.manageScopes": ["registry.admin"],
+
   // export service
   "export.create": ["common"],
   "export.list": ["common"],

--- a/api/src/pdc/services/auth/config/permissions.unit.spec.ts
+++ b/api/src/pdc/services/auth/config/permissions.unit.spec.ts
@@ -17,4 +17,13 @@ describe("permissions", () => {
     const perms = getPermissions("operator.admin");
     assertEquals(perms.some((p) => p.startsWith("common.")), true);
   });
+
+  it("grants registry.user.manageScopes to registry.admin only", () => {
+    assertEquals(getPermissions("registry.admin").includes("registry.user.manageScopes"), true);
+  });
+
+  it("denies manageScopes to territory.admin and operator.admin", () => {
+    assertEquals(getPermissions("territory.admin").some((p) => p.endsWith("user.manageScopes")), false);
+    assertEquals(getPermissions("operator.admin").some((p) => p.endsWith("user.manageScopes")), false);
+  });
 });

--- a/api/src/pdc/services/auth/providers/SessionRepository.integration.spec.ts
+++ b/api/src/pdc/services/auth/providers/SessionRepository.integration.spec.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+import { env_or_default } from "@/lib/env/index.ts";
+import { SESSION_KEY_PREFIX } from "@/pdc/proxy/middlewares/sessionMiddleware.ts";
+import { Redis } from "dep:redis";
+import { SessionRepository } from "./SessionRepository.ts";
+
+describe("SessionRepository.destroyByUser", () => {
+  const redisUrl = env_or_default("APP_REDIS_URL", "redis://127.0.0.1:6379");
+  let client: Redis;
+  let repository: SessionRepository;
+
+  // Config minimale : SessionRepository ne lit que connections.redis.
+  const config = { get: (_key: string) => redisUrl } as unknown as ConstructorParameters<typeof SessionRepository>[0];
+
+  const key = (sid: string) => `${SESSION_KEY_PREFIX}${sid}`;
+
+  beforeAll(async () => {
+    client = new Redis(redisUrl);
+    repository = new SessionRepository(config);
+    await client.set(key("sid-a"), JSON.stringify({ cookie: {}, user: { _id: 4242 } }));
+    await client.set(key("sid-b"), JSON.stringify({ cookie: {}, user: { _id: 4242 } }));
+    await client.set(key("sid-c"), JSON.stringify({ cookie: {}, user: { _id: 9999 } }));
+  });
+
+  afterAll(async () => {
+    await client.del(key("sid-a"), key("sid-b"), key("sid-c"));
+    await client.quit();
+  });
+
+  it("destroys every session of the target user, keeps others", async () => {
+    await repository.destroyByUser(4242);
+
+    assertEquals(await client.exists(key("sid-a")), 0);
+    assertEquals(await client.exists(key("sid-b")), 0);
+    assertEquals(await client.exists(key("sid-c")), 1); // autre user intact
+  });
+});

--- a/api/src/pdc/services/auth/providers/SessionRepository.integration.spec.ts
+++ b/api/src/pdc/services/auth/providers/SessionRepository.integration.spec.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "dep:assert";
+import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
+import { env_or_default } from "@/lib/env/index.ts";
+import { SESSION_KEY_PREFIX } from "@/pdc/proxy/middlewares/sessionMiddleware.ts";
+import { Redis } from "dep:redis";
+import { SessionRepository } from "./SessionRepository.ts";
+
+describe("SessionRepository.destroyByUser", () => {
+  const redisUrl = env_or_default("APP_REDIS_URL", "redis://127.0.0.1:6379");
+  let client: Redis;
+  let repository: SessionRepository;
+
+  // Config minimale : SessionRepository ne lit que connections.redis.
+  const config = { get: (_key: string) => redisUrl } as unknown as ConstructorParameters<typeof SessionRepository>[0];
+
+  const key = (sid: string) => `${SESSION_KEY_PREFIX}${sid}`;
+
+  beforeAll(async () => {
+    client = new Redis(redisUrl);
+    repository = new SessionRepository(config);
+    await client.set(key("sid-a"), JSON.stringify({ cookie: {}, user: { _id: 4242 } }));
+    await client.set(key("sid-b"), JSON.stringify({ cookie: {}, user: { _id: 4242 } }));
+    await client.set(key("sid-c"), JSON.stringify({ cookie: {}, user: { _id: 9999 } }));
+  });
+
+  afterAll(async () => {
+    await client.del(key("sid-a"), key("sid-b"), key("sid-c"));
+    await client.quit();
+    await repository.close();
+  });
+
+  it("destroys every session of the target user, keeps others", async () => {
+    await repository.destroyByUser(4242);
+
+    assertEquals(await client.exists(key("sid-a")), 0);
+    assertEquals(await client.exists(key("sid-b")), 0);
+    assertEquals(await client.exists(key("sid-c")), 1); // autre user intact
+  });
+});

--- a/api/src/pdc/services/auth/providers/SessionRepository.ts
+++ b/api/src/pdc/services/auth/providers/SessionRepository.ts
@@ -1,0 +1,52 @@
+import { ConfigInterfaceResolver, provider } from "@/ilos/common/index.ts";
+import { logger } from "@/lib/logger/index.ts";
+import { SESSION_KEY_PREFIX } from "@/pdc/proxy/middlewares/sessionMiddleware.ts";
+import { Redis } from "dep:redis";
+
+/**
+ * Purge des sessions Redis d'un utilisateur.
+ *
+ * connect-redis n'indexe pas les sessions par user : elles sont stockées sous
+ * `${SESSION_KEY_PREFIX}<sid>` avec une valeur JSON `{ cookie, user }`. Faute d'index,
+ * on scanne le préfixe et on filtre sur `user._id` (approche pragmatique, cf. plan T4).
+ * Volume attendu faible (sessions d'agents), SCAN non bloquant par lots.
+ */
+@provider()
+export class SessionRepository {
+  private client: Redis | null = null;
+
+  constructor(private config: ConfigInterfaceResolver) {}
+
+  protected getClient(): Redis {
+    if (!this.client) {
+      this.client = new Redis(this.config.get("connections.redis"));
+    }
+    return this.client;
+  }
+
+  // Détruit toutes les sessions Redis appartenant à l'utilisateur donné.
+  async destroyByUser(userId: number): Promise<void> {
+    const client = this.getClient();
+    const pattern = `${SESSION_KEY_PREFIX}*`;
+    let cursor = 0;
+
+    do {
+      const [cur, keys] = await client.scan(cursor, "MATCH", pattern, "COUNT", 100);
+      cursor = parseInt(cur, 10);
+
+      for (const key of keys) {
+        const raw = await client.get(key);
+        if (!raw) continue;
+        try {
+          const session = JSON.parse(raw);
+          if (session?.user?._id === userId) {
+            await client.del(key);
+          }
+        } catch (_e) {
+          // Session non-JSON ou corrompue : on l'ignore (ne bloque pas la purge).
+          logger.warn(`[session] clé non parsable ignorée: ${key}`);
+        }
+      }
+    } while (cursor > 0);
+  }
+}

--- a/api/src/pdc/services/auth/providers/SessionRepository.ts
+++ b/api/src/pdc/services/auth/providers/SessionRepository.ts
@@ -1,0 +1,58 @@
+import { ConfigInterfaceResolver, provider } from "@/ilos/common/index.ts";
+import { logger } from "@/lib/logger/index.ts";
+import { SESSION_KEY_PREFIX } from "@/pdc/proxy/middlewares/sessionMiddleware.ts";
+import { Redis } from "dep:redis";
+
+/**
+ * Purge des sessions Redis d'un utilisateur.
+ *
+ * connect-redis n'indexe pas les sessions par user : elles sont stockées sous
+ * `${SESSION_KEY_PREFIX}<sid>` avec une valeur JSON `{ cookie, user }`. Faute d'index,
+ * on scanne le préfixe et on filtre sur `user._id` (approche pragmatique, cf. plan T4).
+ * Volume attendu faible (sessions d'agents), SCAN non bloquant par lots.
+ */
+@provider()
+export class SessionRepository {
+  private client: Redis | null = null;
+
+  constructor(private config: ConfigInterfaceResolver) {}
+
+  protected getClient(): Redis {
+    if (!this.client) {
+      this.client = new Redis(this.config.get("connections.redis"));
+    }
+    return this.client;
+  }
+
+  // Ferme la connexion Redis dédiée (lifecycle des tests, arrêt du service).
+  async close(): Promise<void> {
+    await this.client?.quit();
+    this.client = null;
+  }
+
+  // Détruit toutes les sessions Redis appartenant à l'utilisateur donné.
+  async destroyByUser(userId: number): Promise<void> {
+    const client = this.getClient();
+    const pattern = `${SESSION_KEY_PREFIX}*`;
+    let cursor = 0;
+
+    do {
+      const [cur, keys] = await client.scan(cursor, "MATCH", pattern, "COUNT", 100);
+      cursor = parseInt(cur, 10);
+
+      for (const key of keys) {
+        const raw = await client.get(key);
+        if (!raw) continue;
+        try {
+          const session = JSON.parse(raw);
+          if (session?.user?._id === userId) {
+            await client.del(key);
+          }
+        } catch (_e) {
+          // Session non-JSON ou corrompue : on l'ignore (ne bloque pas la purge).
+          logger.warn(`[session] clé non parsable ignorée: ${key}`);
+        }
+      }
+    } while (cursor > 0);
+  }
+}

--- a/api/src/pdc/services/dashboard/DashboardServiceProvider.ts
+++ b/api/src/pdc/services/dashboard/DashboardServiceProvider.ts
@@ -4,6 +4,9 @@ import { defaultMiddlewareBindings } from "../../providers/middleware/index.ts";
 import { defaultNotificationBindings } from "../../providers/notification/index.ts";
 import { S3StorageProvider } from "../../providers/storage/index.ts";
 import { ValidatorMiddleware } from "../../providers/superstruct/ValidatorMiddleware.ts";
+import { SessionRepository } from "../auth/providers/SessionRepository.ts";
+import { UserScopeRepository } from "../auth/providers/UserScopeRepository.ts";
+import { userScopeGuardMiddlewareBinding } from "./middlewares/UserScopeGuardMiddleware.ts";
 import { CampaignApdfAction } from "./actions/CampaignApdfAction.ts";
 import { CampaignsAction } from "./actions/CampaignsAction.ts";
 import { JourneysIncentiveByDayAction } from "./actions/JourneysIncentiveByDayAction.ts";
@@ -40,6 +43,8 @@ import { UsersRepository } from "./providers/UsersRepository.ts";
     JourneysRepository,
     CampaignsRepository,
     UsersRepository,
+    UserScopeRepository,
+    SessionRepository,
     ...defaultNotificationBindings,
   ],
   handlers: [
@@ -63,6 +68,6 @@ import { UsersRepository } from "./providers/UsersRepository.ts";
   middlewares: [...defaultMiddlewareBindings, [
     "validate",
     ValidatorMiddleware,
-  ]],
+  ], userScopeGuardMiddlewareBinding],
 })
 export class DashboardServiceProvider extends AbstractServiceProvider {}

--- a/api/src/pdc/services/dashboard/actions/users/CreateUserAction.ts
+++ b/api/src/pdc/services/dashboard/actions/users/CreateUserAction.ts
@@ -1,6 +1,7 @@
 import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { copyGroupIdAndApplyGroupPermissionMiddlewares } from "@/pdc/providers/middleware/index.ts";
+import { userScopeGuardMiddleware } from "@/pdc/services/dashboard/middlewares/UserScopeGuardMiddleware.ts";
 import { CreateUser } from "@/pdc/services/dashboard/dto/Users.ts";
 import { BrevoProviderInterfaceResolver } from "@/pdc/services/dashboard/interfaces/BrevoProviderInterface.ts";
 import { OperatorsRepositoryInterfaceResolver } from "@/pdc/services/dashboard/interfaces/OperatorsRepositoryInterface.ts";
@@ -22,6 +23,7 @@ export type ResultInterface = {
       territory: "territory.user.create",
       operator: "operator.user.create",
     }),
+    userScopeGuardMiddleware(),
   ],
   apiRoute: {
     path: "/dashboard/user",

--- a/api/src/pdc/services/dashboard/actions/users/DeleteUserAction.ts
+++ b/api/src/pdc/services/dashboard/actions/users/DeleteUserAction.ts
@@ -1,6 +1,7 @@
 import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { copyGroupIdAndApplyGroupPermissionMiddlewares } from "@/pdc/providers/middleware/index.ts";
+import { SessionRepository } from "@/pdc/services/auth/providers/SessionRepository.ts";
 import { DeleteUser } from "@/pdc/services/dashboard/dto/Users.ts";
 import { UsersRepositoryInterfaceResolver } from "@/pdc/services/dashboard/interfaces/UsersRepositoryInterface.ts";
 export type ResultInterface = {
@@ -26,11 +27,17 @@ export type ResultInterface = {
   },
 })
 export class DeleteUserAction extends AbstractAction {
-  constructor(private repository: UsersRepositoryInterfaceResolver) {
+  constructor(
+    private repository: UsersRepositoryInterfaceResolver,
+    private sessionRepository: SessionRepository,
+  ) {
     super();
   }
 
   public override async handle(params: DeleteUser): Promise<ResultInterface> {
-    return this.repository.deleteUser(params);
+    const result = await this.repository.deleteUser(params);
+    // ON DELETE CASCADE nettoie user_scopes ; on purge aussi les sessions Redis.
+    await this.sessionRepository.destroyByUser(params.id);
+    return result;
   }
 }

--- a/api/src/pdc/services/dashboard/actions/users/UpdateUserAction.ts
+++ b/api/src/pdc/services/dashboard/actions/users/UpdateUserAction.ts
@@ -1,6 +1,8 @@
 import { handler } from "@/ilos/common/index.ts";
 import { Action as AbstractAction } from "@/ilos/core/index.ts";
 import { copyGroupIdAndApplyGroupPermissionMiddlewares } from "@/pdc/providers/middleware/index.ts";
+import { SessionRepository } from "@/pdc/services/auth/providers/SessionRepository.ts";
+import { userScopeGuardMiddleware } from "@/pdc/services/dashboard/middlewares/UserScopeGuardMiddleware.ts";
 import { UpdateUser } from "@/pdc/services/dashboard/dto/Users.ts";
 import { UsersRepositoryInterfaceResolver } from "@/pdc/services/dashboard/interfaces/UsersRepositoryInterface.ts";
 export type ResultInterface = {
@@ -18,6 +20,7 @@ export type ResultInterface = {
       territory: "territory.user.update",
       operator: "operator.user.update",
     }),
+    userScopeGuardMiddleware(),
   ],
   apiRoute: {
     path: "/dashboard/user",
@@ -26,11 +29,17 @@ export type ResultInterface = {
   },
 })
 export class UpdateUserAction extends AbstractAction {
-  constructor(private repository: UsersRepositoryInterfaceResolver) {
+  constructor(
+    private repository: UsersRepositoryInterfaceResolver,
+    private sessionRepository: SessionRepository,
+  ) {
     super();
   }
 
   public override async handle(data: UpdateUser): Promise<ResultInterface> {
-    return this.repository.updateUser(data);
+    const result = await this.repository.updateUser(data);
+    // Toute modification (rôle/périmètre) invalide les sessions : re-login avec des scopes frais.
+    await this.sessionRepository.destroyByUser(data.id);
+    return result;
   }
 }

--- a/api/src/pdc/services/dashboard/dto/Users.ts
+++ b/api/src/pdc/services/dashboard/dto/Users.ts
@@ -1,5 +1,9 @@
-import { Infer, object, optional } from "@/lib/superstruct/index.ts";
+import { array, Infer, object, optional } from "@/lib/superstruct/index.ts";
+import { nullable, pattern, string } from "@/lib/superstruct/index.ts";
 import { Email, Id, NullableId, Role, Varchar } from "@/pdc/providers/superstruct/shared/index.ts";
+
+// SIREN de connexion ProConnect : 9 chiffres, distinct du SIRET du territoire.
+export const LoginSiren = nullable(pattern(string(), /^\d{9}$/));
 
 export const Users = object({
   id: optional(Id),
@@ -17,6 +21,8 @@ export const CreateUser = object({
   role: Role,
   operator_id: optional(NullableId),
   territory_id: optional(NullableId),
+  login_siren: optional(LoginSiren),
+  scopes: optional(array(Id)),
 });
 
 export const DeleteUser = object({
@@ -31,6 +37,8 @@ export const UpdateUser = object({
   role: Role,
   operator_id: optional(NullableId),
   territory_id: optional(NullableId),
+  login_siren: optional(LoginSiren),
+  scopes: optional(array(Id)),
 });
 
 export type Users = Infer<typeof Users>;

--- a/api/src/pdc/services/dashboard/middlewares/UserScopeGuardMiddleware.ts
+++ b/api/src/pdc/services/dashboard/middlewares/UserScopeGuardMiddleware.ts
@@ -1,0 +1,74 @@
+import {
+  ContextType,
+  ForbiddenException,
+  middleware,
+  MiddlewareInterface,
+  ParamsType,
+  ResultType,
+} from "@/ilos/common/index.ts";
+import { get } from "@/lib/object/index.ts";
+import { NextFunction } from "dep:express";
+import { ConfiguredMiddleware } from "@/pdc/providers/middleware/interfaces.ts";
+
+// Permission de manipulation des champs privilégiés, détenue par registry.admin seul.
+export const MANAGE_SCOPES_PERMISSION = "registry.user.manageScopes";
+
+// Rang hiérarchique : plus grand = plus de privilèges (registry.admin au sommet, inconnu = 0 fail-closed).
+const ROLE_RANK: Record<string, number> = {
+  "operator.user": 1,
+  "territory.user": 1,
+  "registry.user": 3,
+  "operator.admin": 2,
+  "territory.admin": 2,
+  "registry.admin": 4,
+};
+
+export function roleRank(role: string): number {
+  return ROLE_RANK[role] ?? 0;
+}
+
+// Détecte l'octroi d'un scope multi-territoire (tableau de territoires non vide).
+function grantsMultiScope(params: ParamsType): boolean {
+  const scopes: unknown = get(params, "scopes", undefined);
+  return Array.isArray(scopes) && scopes.length > 0;
+}
+
+/**
+ * Garde les actions create/update user :
+ * - champs privilégiés (login_siren, octroi de scope multi-territoire) réservés à MANAGE_SCOPES_PERMISSION ;
+ * - interdit d'attribuer un rôle de rang supérieur à celui du caller (anti-escalade).
+ */
+@middleware()
+export class UserScopeGuardMiddleware implements MiddlewareInterface {
+  async process(
+    params: ParamsType,
+    context: ContextType,
+    next: NextFunction,
+  ): Promise<ResultType> {
+    const permissions = (get(context, "call.user.permissions", []) || []) as string[];
+    const callerRole = get(context, "call.user.role", "") as string;
+    const hasManageScopes = permissions.includes(MANAGE_SCOPES_PERMISSION);
+
+    // Gate champ privilégié : login_siren / octroi multi-territoire sans la permission → refus.
+    const asksPrivileged = get(params, "login_siren", null) != null || grantsMultiScope(params);
+    if (asksPrivileged && !hasManageScopes) {
+      throw new ForbiddenException("login_siren / octroi de scope réservé à registry.admin");
+    }
+
+    // Garde hiérarchie : ne pas attribuer un rôle plus privilégié que soi.
+    const targetRole = get(params, "role", "") as string;
+    if (targetRole && roleRank(targetRole) > roleRank(callerRole)) {
+      throw new ForbiddenException("Attribution d'un rôle de rang supérieur interdite");
+    }
+
+    return next(params, context);
+  }
+}
+
+const alias = "dashboard.user_scope_guard";
+
+export const userScopeGuardMiddlewareBinding = [alias, UserScopeGuardMiddleware];
+
+export function userScopeGuardMiddleware(): ConfiguredMiddleware<undefined> {
+  return [alias, undefined];
+}

--- a/api/src/pdc/services/dashboard/middlewares/UserScopeGuardMiddleware.unit.spec.ts
+++ b/api/src/pdc/services/dashboard/middlewares/UserScopeGuardMiddleware.unit.spec.ts
@@ -1,0 +1,78 @@
+import { assertEquals, assertRejects } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import { ContextType, ForbiddenException } from "@/ilos/common/index.ts";
+import { roleRank, UserScopeGuardMiddleware } from "./UserScopeGuardMiddleware.ts";
+
+describe("UserScopeGuardMiddleware", () => {
+  const middleware = new UserScopeGuardMiddleware();
+  const next = async () => "next() called";
+
+  const ctx = (user: Record<string, unknown>): ContextType => ({
+    call: { user },
+    channel: { service: "proxy" },
+  });
+
+  const registryAdmin = { role: "registry.admin", permissions: ["registry.user.manageScopes", "registry.user.create"] };
+  const territoryAdmin = { role: "territory.admin", permissions: ["territory.user.create"] };
+
+  it("roleRank: registry.admin outranks territory.admin outranks territory.user", () => {
+    assertEquals(roleRank("registry.admin") > roleRank("territory.admin"), true);
+    assertEquals(roleRank("territory.admin") > roleRank("territory.user"), true);
+    assertEquals(roleRank("registry.user") > roleRank("territory.admin"), true);
+    assertEquals(roleRank("unknown"), 0);
+  });
+
+  it("403 when territory.admin assigns role registry.admin (hierarchy)", async () => {
+    await assertRejects(
+      () => middleware.process({ role: "registry.admin" }, ctx(territoryAdmin), next, undefined),
+      ForbiddenException,
+    );
+  });
+
+  it("403 when territory.admin assigns role registry.user (hierarchy)", async () => {
+    await assertRejects(
+      () => middleware.process({ role: "registry.user" }, ctx(territoryAdmin), next, undefined),
+      ForbiddenException,
+    );
+  });
+
+  it("OK when territory.admin assigns a peer territory.admin", async () => {
+    assertEquals(
+      await middleware.process({ role: "territory.admin" }, ctx(territoryAdmin), next, undefined),
+      "next() called",
+    );
+  });
+
+  it("OK when registry.admin creates a registry.admin peer", async () => {
+    assertEquals(
+      await middleware.process({ role: "registry.admin" }, ctx(registryAdmin), next, undefined),
+      "next() called",
+    );
+  });
+
+  it("403 when territory.admin provides login_siren (privileged field)", async () => {
+    await assertRejects(
+      () => middleware.process({ role: "territory.admin", login_siren: "123456789" }, ctx(territoryAdmin), next, undefined),
+      ForbiddenException,
+    );
+  });
+
+  it("403 when territory.admin grants a multi-territory scope", async () => {
+    await assertRejects(
+      () => middleware.process({ role: "territory.admin", scopes: [1, 2] }, ctx(territoryAdmin), next, undefined),
+      ForbiddenException,
+    );
+  });
+
+  it("OK when registry.admin provides login_siren + scopes", async () => {
+    assertEquals(
+      await middleware.process(
+        { role: "registry.admin", login_siren: "123456789", scopes: [1, 2] },
+        ctx(registryAdmin),
+        next,
+        undefined,
+      ),
+      "next() called",
+    );
+  });
+});

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
@@ -1,7 +1,9 @@
 import { assertEquals, assertRejects } from "dep:assert";
 import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
 import { NotFoundException } from "@/ilos/common/index.ts";
+import sql from "@/lib/pg/sql.ts";
 import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/index.ts";
+import { UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
 import { UsersRepository } from "./UsersRepository.ts";
 
 describe("UsersRepository", () => {
@@ -11,9 +13,12 @@ describe("UsersRepository", () => {
 
   let createdUserId: number;
 
+  let scopeRepository: UserScopeRepository;
+
   beforeAll(async () => {
     db = await before();
-    repository = new UsersRepository(db.connection);
+    scopeRepository = new UserScopeRepository(db.connection);
+    repository = new UsersRepository(db.connection, scopeRepository);
   });
 
   afterAll(async () => {
@@ -172,5 +177,72 @@ describe("UsersRepository", () => {
     if (bobUsers.data.length > 0) {
       await repository.deleteUser({ id: bobUsers.data[0].id });
     }
+  });
+});
+
+describe("UsersRepository multi-scope (pivot)", () => {
+  let db: DenoDbContext;
+  let repository: UsersRepository;
+  const { before, after } = makeDenoDbBeforeAfter();
+
+  async function ensureTerritory(id: number): Promise<void> {
+    await db.connection.query(sql`
+      INSERT INTO territory.territory_group (_id, company_id, name)
+      VALUES (${id}::int, 1::int, ${`Test territoire ${id}`}::varchar)
+      ON CONFLICT DO NOTHING
+    `);
+  }
+
+  beforeAll(async () => {
+    db = await before();
+    repository = new UsersRepository(db.connection, new UserScopeRepository(db.connection));
+    await ensureTerritory(310);
+    await ensureTerritory(311);
+  });
+
+  afterAll(async () => {
+    await after(db);
+  });
+
+  it("create dual-writes the pivot (default + extra territories)", async () => {
+    await repository.createUser({
+      firstname: "Multi",
+      lastname: "Scope",
+      email: "multi.scope@example.com",
+      role: "territory.admin",
+      operator_id: null,
+      territory_id: 310,
+      scopes: [311],
+    });
+
+    const created = await repository.getUsers({ search: "multi.scope@example.com" });
+    assertEquals(created.data.length, 1);
+    const uid = created.data[0].id;
+
+    const scopeRows = await db.connection.query<{ n: number; d: number }>(sql`
+      SELECT count(*)::int AS n, count(*) FILTER (WHERE is_default)::int AS d
+      FROM auth.user_scopes WHERE user_id = ${uid}
+    `);
+    assertEquals(scopeRows[0].n, 2); // 310 défaut + 311
+    assertEquals(scopeRows[0].d, 1); // exactement un défaut
+  });
+
+  it("list via pivot shows a multi-territory user only once (DISTINCT)", async () => {
+    const byT310 = await repository.getUsers({ territory_id: 310, search: "multi.scope" });
+    assertEquals(byT310.data.length, 1);
+    assertEquals(byT310.meta.total, 1);
+
+    const byT311 = await repository.getUsers({ territory_id: 311, search: "multi.scope" });
+    assertEquals(byT311.data.length, 1);
+  });
+
+  it("delete cascades the pivot rows", async () => {
+    const created = await repository.getUsers({ search: "multi.scope@example.com" });
+    const uid = created.data[0].id;
+    await repository.deleteUser({ id: uid });
+    const scopeRows = await db.connection.query<{ n: number }>(sql`
+      SELECT count(*)::int AS n FROM auth.user_scopes WHERE user_id = ${uid}
+    `);
+    assertEquals(scopeRows[0].n, 0);
   });
 });

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.purge.integration.spec.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.purge.integration.spec.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "dep:assert";
 import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
 import sql from "@/lib/pg/sql.ts";
 import { DenoDbContext, makeDenoDbBeforeAfter } from "@/pdc/providers/test/index.ts";
+import { UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
 import { UsersRepository } from "./UsersRepository.ts";
 
 describe("auth.users deletion_warned_at", () => {
@@ -31,7 +32,7 @@ describe("UsersRepository purge selection", () => {
 
   beforeAll(async () => {
     db = await before();
-    repository = new UsersRepository(db.connection);
+    repository = new UsersRepository(db.connection, new UserScopeRepository(db.connection));
     // A: à avertir (operator, inactif 13 mois, jamais averti)
     await db.connection.query(sql`INSERT INTO auth.users (email, firstname, lastname, role, last_login_at)
       VALUES ('warn@purge.test', 'A', 'A', 'operator.user', now() - '13 months'::interval)`);

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.ts
@@ -1,6 +1,7 @@
 import { NotFoundException, provider } from "@/ilos/common/index.ts";
 import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import sql, { join, raw } from "@/lib/pg/sql.ts";
+import { UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
 import { UserResult } from "@/pdc/services/dashboard/actions/users/UsersAction.ts";
 import {
   CreateUserDataInterface,
@@ -21,27 +22,33 @@ import {
 })
 export class UsersRepository implements UsersRepositoryInterface {
   private readonly table = "auth.users";
+  private readonly tableScopes = "auth.user_scopes";
   private readonly tableTerritory = "territory.territory_group";
   private readonly tableOperator = "operator.operators";
 
-  constructor(private pgConnection: DenoPostgresConnection) {}
+  constructor(
+    private pgConnection: DenoPostgresConnection,
+    private userScopeRepository: UserScopeRepository,
+  ) {}
 
   async getUsers(params: UsersParamsInterface): Promise<UsersResultInterface> {
+    // Filtrage des périmètres via le pivot user_scopes ; LEFT JOIN pour ne pas perdre
+    // les comptes sans scope (ex : registry.admin) lorsque le caller n'impose pas de filtre.
     const filters = [sql`TRUE`];
     if (params.id) {
       filters.push(sql`users._id = ${params.id}`);
     }
     if (params.operator_id) {
-      filters.push(sql`users.operator_id = ${params.operator_id}`);
+      filters.push(sql`us.operator_id = ${params.operator_id}`);
     }
     if (params.territory_id) {
-      filters.push(sql`users.territory_id = ${params.territory_id}`);
+      filters.push(sql`us.territory_id = ${params.territory_id}`);
     }
     if (params.search) {
       filters.push(sql`(
-        users.firstname ILIKE ${`%${params.search}%`} 
-        OR users.lastname ILIKE ${`%${params.search}%`} 
-        OR users.email ILIKE ${`%${params.search}%`} 
+        users.firstname ILIKE ${`%${params.search}%`}
+        OR users.lastname ILIKE ${`%${params.search}%`}
+        OR users.email ILIKE ${`%${params.search}%`}
         OR o.name ILIKE ${`%${params.search}%`}
         OR tg.name ILIKE ${`%${params.search}%`}
       )`);
@@ -49,6 +56,12 @@ export class UsersRepository implements UsersRepositoryInterface {
     const limit = params.limit || 25;
     const page = params.page || 1;
     const offset = (page - 1) * limit;
+    const searchJoin = params.search
+      ? sql`LEFT JOIN ${raw(this.tableTerritory)} tg ON tg._id = users.territory_id LEFT JOIN ${
+        raw(this.tableOperator)
+      } o ON o._id = users.operator_id`
+      : sql``;
+    // GROUP BY users._id (PK) : un user multi-territoires n'apparaît qu'une fois.
     const query = sql`
       SELECT
         users._id as id,
@@ -59,30 +72,21 @@ export class UsersRepository implements UsersRepositoryInterface {
         users.territory_id,
         users.role
       FROM ${raw(this.table)} AS users
-      ${
-      params.search
-        ? sql`LEFT JOIN ${raw(this.tableTerritory)} tg ON tg._id = users.territory_id LEFT JOIN ${
-          raw(this.tableOperator)
-        } o ON o._id = users.operator_id`
-        : sql``
-    }
+      LEFT JOIN ${raw(this.tableScopes)} us ON us.user_id = users._id
+      ${searchJoin}
       WHERE ${join(filters, " AND ")}
+      GROUP BY users._id
       ORDER BY users._id
       LIMIT ${limit} OFFSET ${offset}
     `;
 
     const rows = await this.pgConnection.query<UserResult>(query);
-    // Calcul du nombre total d'éléments
+    // Total = nombre de users distincts (le JOIN pivot démultiplie les lignes).
     const countQuery = sql`
-      SELECT COUNT(*) as total
+      SELECT COUNT(DISTINCT users._id) as total
       FROM ${raw(this.table)} AS users
-      ${
-      params.search
-        ? sql`LEFT JOIN ${raw(this.tableTerritory)} tg ON tg._id = users.territory_id LEFT JOIN ${
-          raw(this.tableOperator)
-        } o ON o._id = users.operator_id`
-        : sql``
-    }
+      LEFT JOIN ${raw(this.tableScopes)} us ON us.user_id = users._id
+      ${searchJoin}
       WHERE ${join(filters, " AND ")}
     `;
     const countResponse = await this.pgConnection.query<{ total: number }>(countQuery);
@@ -98,23 +102,53 @@ export class UsersRepository implements UsersRepositoryInterface {
   }
 
   async createUser(data: CreateUserDataInterface): Promise<CreateUserResultInterface> {
+    // Dual-write (expand) : on écrit encore les colonnes dépréciées operator_id/territory_id + login_siren.
     const query = sql`
       INSERT INTO ${raw(this.table)} (
-        firstname, lastname, email, role, operator_id, territory_id
+        firstname, lastname, email, role, operator_id, territory_id, login_siren
       ) VALUES (
-        ${data.firstname}, ${data.lastname}, ${data.email}, ${data.role}, ${data.operator_id}, ${data.territory_id}
+        ${data.firstname}, ${data.lastname}, ${data.email}, ${data.role}, ${data.operator_id}, ${data.territory_id}, ${
+      data.login_siren ?? null
+    }
       )
       RETURNING
         _id, created_at, firstname, lastname, email, role, operator_id, territory_id
     `;
-    const rows = await this.pgConnection.query(query);
+    const rows = await this.pgConnection.query<{ _id: number }>(query);
     if (rows.length !== 1) {
       throw new Error(`Unable to create user ${data}`);
     }
+    // Source de vérité : le pivot user_scopes (défaut = scope initial).
+    await this.seedScopes(rows[0]._id, data);
     return {
       success: true,
       message: `user ${JSON.stringify(rows[0])} created`,
     };
+  }
+
+  // Reconcilie user_scopes avec le formulaire (défaut + territoires additionnels), via UserScopeRepository.
+  private async seedScopes(
+    userId: number,
+    data: { operator_id?: number | null; territory_id?: number | null; scopes?: number[] },
+  ): Promise<void> {
+    // Reset idempotent (no-op à la création, resynchronise à l'update).
+    await this.pgConnection.query(sql`
+      DELETE FROM ${raw(this.tableScopes)} WHERE user_id = ${userId}
+    `);
+
+    if (data.operator_id) {
+      await this.userScopeRepository.setOperator(userId, data.operator_id);
+      return;
+    }
+
+    const territories: number[] = [];
+    if (data.territory_id) territories.push(data.territory_id);
+    for (const t of data.scopes ?? []) {
+      if (!territories.includes(t)) territories.push(t);
+    }
+    for (let i = 0; i < territories.length; i++) {
+      await this.userScopeRepository.addTerritory(userId, territories[i], i === 0);
+    }
   }
 
   async deleteUser(
@@ -141,15 +175,17 @@ export class UsersRepository implements UsersRepositoryInterface {
   }
 
   async updateUser(data: UpdateUserDataInterface): Promise<UpdateUserResultInterface> {
+    // Dual-write (expand) : colonnes dépréciées + login_siren, puis resynchro du pivot.
     const query = sql`
       UPDATE ${raw(this.table)}
-      SET 
+      SET
         firstname = ${data.firstname},
         lastname = ${data.lastname},
         email = ${data.email},
         role = ${data.role},
         operator_id = ${data.operator_id},
         territory_id = ${data.territory_id},
+        login_siren = ${data.login_siren ?? null},
         updated_at = now()
       WHERE _id = ${data.id}
       RETURNING _id, updated_at, firstname, lastname, email, role, operator_id, territory_id
@@ -158,6 +194,7 @@ export class UsersRepository implements UsersRepositoryInterface {
     if (rows.length !== 1) {
       throw new Error(`Unable to update user with id ${data.id}`);
     }
+    await this.seedScopes(data.id, data);
     return {
       success: true,
       message: `User ${JSON.stringify(rows[0])} updated`,


### PR DESCRIPTION
## Contexte

Tranche **T4** du chantier multi-SIRET/multi-périmètre (GEN-686). Stackée sur T1 (#3318), parallèle à T2 (#3322).
Base de la PR = `feat/gen686-t1-user-scopes` (se retargetera sur `main` au merge de T1).

## Contenu — CRUD dashboard gaté + durcissement autorisation

- **Permission `registry.user.manageScopes`** (détenue par `registry.admin` seul).
- **`UserScopeGuardMiddleware`** : rejette la présence de `login_siren` / d'un octroi de scope multi-territoire si le caller n'a pas la permission ; **garde de hiérarchie de rôle** — interdit d'attribuer un `role` de rang ≥ celui du caller (corrige un **trou d'escalade pré-existant** que le découplage `login_siren` armait).
- **`UsersRepository`** : liste des users d'un groupe via jointure `auth.user_scopes` (`GROUP BY users._id` ⇒ un user multi-territoires apparaît une fois) ; **dual-write** des colonnes dépréciées `operator_id/territory_id` pendant la transition ; seed des scopes à la création.
- **`SessionRepository.destroyByUser`** : purge des sessions Redis d'un utilisateur, branchée sur delete/update ⇒ **la révocation d'un scope coupe l'accès** (sinon la session en cache garde les droits).
- **dto Users** : `login_siren` (`^\d{9}$`, nullable) + `scopes[]`.

## Tests

- Unit : `UserScopeGuardMiddleware` (8 cas), `permissions` — verts en local.
- Intégration : liste pivot/DISTINCT, dual-write, purge Redis — à valider en CI.

## Note (réconciliation au merge)

`UserScopeRepository` est enregistré ici dans `DashboardServiceProvider` et dans `AuthServiceProvider` côté T2 (#3322). Si les conteneurs ILOS sont partagés, dédupliquer au merge des deux sur `main` ; s'ils sont isolés par service, les deux sont nécessaires.
