### PR TITLE
feat(auth): route /auth/context — bascule de périmètre (GEN-686) [T3/6]

### DIFF
--- a/api/src/pdc/services/auth/AuthRouter.context.unit.spec.ts
+++ b/api/src/pdc/services/auth/AuthRouter.context.unit.spec.ts
@@ -1,0 +1,109 @@
+import { assertEquals } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+
+import { UserScope } from "./providers/UserScopeRepository.ts";
+import { contextRoute } from "./AuthRouter.ts";
+
+// Stub du repository : n'accorde que les couples (userId, territoryId) déclarés.
+class StubUserScopeRepository {
+  public calls: Array<[number, number]> = [];
+  constructor(private granted: Array<[number, number]> = []) {}
+  userHasTerritory(userId: number, territoryId: number): Promise<boolean> {
+    this.calls.push([userId, territoryId]);
+    return Promise.resolve(this.granted.some(([u, t]) => u === userId && t === territoryId));
+  }
+}
+
+// Réponse express minimale : capture statut + corps.
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+// Session express minimale : save() résout immédiatement.
+function mockSession(user: Record<string, unknown> | undefined) {
+  return {
+    user,
+    save(cb: (err?: Error) => void) {
+      cb();
+    },
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+async function invoke(repo: StubUserScopeRepository, req: any) {
+  const res = mockRes();
+  let nextErr: unknown = undefined;
+  await contextRoute(repo as never)(req, res, (err: unknown) => (nextErr = err));
+  if (nextErr) throw nextErr;
+  return res;
+}
+
+const territoryScopes: UserScope[] = [
+  { territory_id: 200, label: "AOM Deux Cents" },
+  { territory_id: 201, label: "AOM Deux Cent Un" },
+];
+
+describe("POST /auth/context (contextRoute)", () => {
+  it("401 when no session user", async () => {
+    const repo = new StubUserScopeRepository();
+    const res = await invoke(repo, { session: mockSession(undefined), body: { territory_id: 200 } });
+    assertEquals(res.statusCode, 401);
+  });
+
+  it("400 when territory_id is missing or not a positive integer", async () => {
+    const repo = new StubUserScopeRepository([[7, 200]]);
+    const user = { _id: 7, territory_id: 200, scopes: territoryScopes };
+    for (const body of [{}, { territory_id: 0 }, { territory_id: -3 }, { territory_id: "200" }]) {
+      const res = await invoke(repo, { session: mockSession({ ...user }), body });
+      assertEquals(res.statusCode, 400);
+    }
+  });
+
+  it("403 when the territory is not granted in DB", async () => {
+    const repo = new StubUserScopeRepository([[7, 200]]);
+    const user = { _id: 7, territory_id: 200, scopes: territoryScopes };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 999 } });
+    assertEquals(res.statusCode, 403);
+    // La revalidation interroge bien la DB sur le territory_id demandé.
+    assertEquals(repo.calls, [[7, 999]]);
+  });
+
+  it("403 on op/territory id collision (never treats an operator id as a territory)", async () => {
+    const repo = new StubUserScopeRepository();
+    const user = { _id: 9, operator_id: 42, scopes: [{ operator_id: 42, label: "Op" }] as UserScope[] };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 42 } });
+    assertEquals(res.statusCode, 403);
+    // Refus avant tout appel DB : l'id opérateur n'est jamais revalidé comme territoire.
+    assertEquals(repo.calls, []);
+  });
+
+  it("refuses the switch for an operator-type user", async () => {
+    const repo = new StubUserScopeRepository([[9, 200]]);
+    const user = { _id: 9, operator_id: 5, scopes: [{ operator_id: 5, label: "Op" }] as UserScope[] };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 200 } });
+    assertEquals(res.statusCode, 403);
+    assertEquals(repo.calls, []);
+  });
+
+  it("200 and rewrites the full active tuple (operator_id=null) when granted", async () => {
+    const repo = new StubUserScopeRepository([[7, 201]]);
+    const user: Record<string, unknown> = { _id: 7, territory_id: 200, operator_id: undefined, scopes: territoryScopes };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 201 } });
+    assertEquals(res.statusCode, 200);
+    assertEquals(res.body, { territory_id: 201, label: "AOM Deux Cent Un" });
+    // Tuple actif réécrit : territoire ciblé, opérateur purgé.
+    assertEquals(user.territory_id, 201);
+    assertEquals(user.operator_id, null);
+  });
+});

--- a/api/src/pdc/services/auth/AuthRouter.ts
+++ b/api/src/pdc/services/auth/AuthRouter.ts
@@ -2,6 +2,7 @@ import { ConfigInterfaceResolver, inject, injectable, KernelInterfaceResolver, p
 import { logger } from "@/lib/logger/index.ts";
 import { asyncHandler } from "@/pdc/proxy/helpers/asyncHandler.ts";
 import { ProConnectOIDCProvider } from "@/pdc/services/auth/providers/ProConnectOIDCProvider.ts";
+import { UserScope, UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
 import express, { NextFunction, Request, Response } from "dep:express";
 import { session } from "../../../config/proxy.ts";
 import { authGuard } from "../../proxy/middlewares/authGuard.ts";
@@ -15,6 +16,7 @@ export class AuthRouter {
     private kernel: KernelInterfaceResolver,
     private proConnectOIDCProvider: ProConnectOIDCProvider,
     private config: ConfigInterfaceResolver,
+    private userScopeRepository: UserScopeRepository,
   ) {
   }
 
@@ -115,6 +117,9 @@ export class AuthRouter {
       },
     );
 
+    // Bascule du contexte actif (users territoire) — revalidée en DB, cf. spec §6.
+    this.app.post("/auth/context", contextRoute(this.userScopeRepository));
+
     /**
      * Test-only login route to create a session without going through OIDC.
      * This route should only be available in test environments.
@@ -123,4 +128,50 @@ export class AuthRouter {
       this.app.post("/auth/test/callback", testCallbackRoute.bind(this)(this.config));
     }
   }
+}
+
+// Réponse d'erreur au format JSON-RPC (même forme que /auth/me).
+function jsonRpcError(res: Response, code: number, message: string) {
+  return res.status(code).json({ id: 1, jsonrpc: "2.0", error: { code, data: "Error", message } });
+}
+
+// Type opérateur : scope actif opérateur, ou présence d'au moins un scope opérateur.
+function isOperatorUser(user: { operator_id?: number | null; scopes?: UserScope[] }): boolean {
+  if (user.operator_id != null) return true;
+  return (user.scopes ?? []).some((s) => s.operator_id != null);
+}
+
+/**
+ * Bascule le contexte actif d'un user territoire vers un de ses territoires.
+ * La liste session.scopes[] ne sert qu'à l'affichage ; l'autorisation vient de la DB.
+ */
+export function contextRoute(userScopeRepository: UserScopeRepository) {
+  return asyncHandler(async (req: Request, res: Response) => {
+    // 401 : garde locale, ne dépend d'aucun middleware qui no-op sur le cookie.
+    if (!req.session?.user) return jsonRpcError(res, 401, "Unauthorized Error");
+    const user = req.session.user;
+
+    // Body : territory_id entier strictement positif requis.
+    const territoryId = req.body?.territory_id;
+    if (!Number.isInteger(territoryId) || territoryId <= 0) return jsonRpcError(res, 400, "Bad Request");
+
+    // Seul un user de type territoire bascule ; un opérateur n'a qu'un scope.
+    if (isOperatorUser(user)) return jsonRpcError(res, 403, "Forbidden Error");
+
+    // Revalidation DB : match strict sur territory_id (anti-IDOR par collision op/territoire).
+    if (!(await userScopeRepository.userHasTerritory(user._id, territoryId))) {
+      return jsonRpcError(res, 403, "Forbidden Error");
+    }
+
+    // Réécrit tout le tuple actif : territoire ciblé, opérateur purgé.
+    user.territory_id = territoryId;
+    user.operator_id = null;
+    await new Promise<void>((resolve, reject) =>
+      req.session.save((err: Error) => err ? reject(err) : resolve())
+    );
+
+    // Libellé d'affichage depuis les scopes autorisés (fallback vide).
+    const label = (user.scopes ?? []).find((s: UserScope) => s.territory_id === territoryId)?.label ?? "";
+    return res.json({ territory_id: territoryId, label });
+  });
 }

--- a/api/src/pdc/services/auth/AuthRouter.ts
+++ b/api/src/pdc/services/auth/AuthRouter.ts
@@ -2,10 +2,12 @@ import { ConfigInterfaceResolver, inject, injectable, KernelInterfaceResolver, p
 import { logger } from "@/lib/logger/index.ts";
 import { asyncHandler } from "@/pdc/proxy/helpers/asyncHandler.ts";
 import { ProConnectOIDCProvider } from "@/pdc/services/auth/providers/ProConnectOIDCProvider.ts";
+import { UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
 import express, { NextFunction, Request, Response } from "dep:express";
 import { session } from "../../../config/proxy.ts";
 import { authGuard } from "../../proxy/middlewares/authGuard.ts";
 import { sessionMiddleware } from "../../proxy/middlewares/sessionMiddleware.ts";
+import { contextRoute } from "./context.ts";
 import { testCallbackRoute } from "./test/callback.ts";
 
 @injectable()
@@ -15,6 +17,7 @@ export class AuthRouter {
     private kernel: KernelInterfaceResolver,
     private proConnectOIDCProvider: ProConnectOIDCProvider,
     private config: ConfigInterfaceResolver,
+    private userScopeRepository: UserScopeRepository,
   ) {
   }
 
@@ -53,9 +56,7 @@ export class AuthRouter {
         // Store user and token information in the fresh session
         req.session.auth = { id_token: tokens.id_token };
         req.session.user = user;
-        await new Promise<void>((resolve, reject) =>
-          req.session.save((err: Error) => err ? reject(err) : resolve())
-        );
+        await new Promise<void>((resolve, reject) => req.session.save((err: Error) => err ? reject(err) : resolve()));
 
         return res.redirect(this.config.get("app_url"));
       }),
@@ -114,6 +115,9 @@ export class AuthRouter {
         return res.json(req.session?.user);
       },
     );
+
+    // Bascule du contexte actif (users territoire) — revalidée en DB, cf. spec §6.
+    this.app.post("/auth/context", contextRoute(this.userScopeRepository));
 
     /**
      * Test-only login route to create a session without going through OIDC.

--- a/api/src/pdc/services/auth/context.ts
+++ b/api/src/pdc/services/auth/context.ts
@@ -1,0 +1,47 @@
+import { asyncHandler } from "@/pdc/proxy/helpers/asyncHandler.ts";
+import { UserScope, UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
+import { Request, Response } from "dep:express";
+
+// Réponse d'erreur au format JSON-RPC (même forme que /auth/me).
+function jsonRpcError(res: Response, code: number, message: string) {
+  return res.status(code).json({ id: 1, jsonrpc: "2.0", error: { code, data: "Error", message } });
+}
+
+// Type opérateur : scope actif opérateur, ou présence d'au moins un scope opérateur.
+function isOperatorUser(user: { operator_id?: number | null; scopes?: UserScope[] }): boolean {
+  if (user.operator_id != null) return true;
+  return (user.scopes ?? []).some((s) => s.operator_id != null);
+}
+
+/**
+ * Bascule le contexte actif d'un user territoire vers un de ses territoires.
+ * La liste session.scopes[] ne sert qu'à l'affichage ; l'autorisation vient de la DB.
+ */
+export function contextRoute(userScopeRepository: UserScopeRepository) {
+  return asyncHandler(async (req: Request, res: Response) => {
+    // 401 : garde locale, ne dépend d'aucun middleware qui no-op sur le cookie.
+    if (!req.session?.user) return jsonRpcError(res, 401, "Unauthorized Error");
+    const user = req.session.user;
+
+    // Body : territory_id entier strictement positif requis.
+    const territoryId = req.body?.territory_id;
+    if (!Number.isInteger(territoryId) || territoryId <= 0) return jsonRpcError(res, 400, "Bad Request");
+
+    // Seul un user de type territoire bascule ; un opérateur n'a qu'un scope.
+    if (isOperatorUser(user)) return jsonRpcError(res, 403, "Forbidden Error");
+
+    // Revalidation DB : match strict sur territory_id (anti-IDOR par collision op/territoire).
+    if (!(await userScopeRepository.userHasTerritory(user._id, territoryId))) {
+      return jsonRpcError(res, 403, "Forbidden Error");
+    }
+
+    // Réécrit tout le tuple actif : territoire ciblé, opérateur purgé.
+    user.territory_id = territoryId;
+    user.operator_id = null;
+    await new Promise<void>((resolve, reject) => req.session.save((err: Error) => err ? reject(err) : resolve()));
+
+    // Libellé d'affichage depuis les scopes autorisés (fallback vide).
+    const label = (user.scopes ?? []).find((s: UserScope) => s.territory_id === territoryId)?.label ?? "";
+    return res.json({ territory_id: territoryId, label });
+  });
+}

--- a/api/src/pdc/services/auth/context.unit.spec.ts
+++ b/api/src/pdc/services/auth/context.unit.spec.ts
@@ -1,0 +1,114 @@
+import { assertEquals } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+
+import { UserScope } from "./providers/UserScopeRepository.ts";
+import { contextRoute } from "./context.ts";
+
+// Stub du repository : n'accorde que les couples (userId, territoryId) déclarés.
+class StubUserScopeRepository {
+  public calls: Array<[number, number]> = [];
+  constructor(private granted: Array<[number, number]> = []) {}
+  userHasTerritory(userId: number, territoryId: number): Promise<boolean> {
+    this.calls.push([userId, territoryId]);
+    return Promise.resolve(this.granted.some(([u, t]) => u === userId && t === territoryId));
+  }
+}
+
+// Réponse express minimale : capture statut + corps.
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+// Session express minimale : save() résout immédiatement.
+function mockSession(user: Record<string, unknown> | undefined) {
+  return {
+    user,
+    save(cb: (err?: Error) => void) {
+      cb();
+    },
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+async function invoke(repo: StubUserScopeRepository, req: any) {
+  const res = mockRes();
+  let nextErr: unknown = undefined;
+  await contextRoute(repo as never)(req, res, (err: unknown) => (nextErr = err));
+  if (nextErr) throw nextErr;
+  return res;
+}
+
+const territoryScopes: UserScope[] = [
+  { territory_id: 200, label: "AOM Deux Cents" },
+  { territory_id: 201, label: "AOM Deux Cent Un" },
+];
+
+describe("POST /auth/context (contextRoute)", () => {
+  it("401 when no session user", async () => {
+    const repo = new StubUserScopeRepository();
+    const res = await invoke(repo, { session: mockSession(undefined), body: { territory_id: 200 } });
+    assertEquals(res.statusCode, 401);
+  });
+
+  it("400 when territory_id is missing or not a positive integer", async () => {
+    const repo = new StubUserScopeRepository([[7, 200]]);
+    const user = { _id: 7, territory_id: 200, scopes: territoryScopes };
+    for (const body of [{}, { territory_id: 0 }, { territory_id: -3 }, { territory_id: "200" }]) {
+      const res = await invoke(repo, { session: mockSession({ ...user }), body });
+      assertEquals(res.statusCode, 400);
+    }
+  });
+
+  it("403 when the territory is not granted in DB", async () => {
+    const repo = new StubUserScopeRepository([[7, 200]]);
+    const user = { _id: 7, territory_id: 200, scopes: territoryScopes };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 999 } });
+    assertEquals(res.statusCode, 403);
+    // La revalidation interroge bien la DB sur le territory_id demandé.
+    assertEquals(repo.calls, [[7, 999]]);
+  });
+
+  it("403 on op/territory id collision (never treats an operator id as a territory)", async () => {
+    const repo = new StubUserScopeRepository();
+    const user = { _id: 9, operator_id: 42, scopes: [{ operator_id: 42, label: "Op" }] as UserScope[] };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 42 } });
+    assertEquals(res.statusCode, 403);
+    // Refus avant tout appel DB : l'id opérateur n'est jamais revalidé comme territoire.
+    assertEquals(repo.calls, []);
+  });
+
+  it("refuses the switch for an operator-type user", async () => {
+    const repo = new StubUserScopeRepository([[9, 200]]);
+    const user = { _id: 9, operator_id: 5, scopes: [{ operator_id: 5, label: "Op" }] as UserScope[] };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 200 } });
+    assertEquals(res.statusCode, 403);
+    assertEquals(repo.calls, []);
+  });
+
+  it("200 and rewrites the full active tuple (operator_id=null) when granted", async () => {
+    const repo = new StubUserScopeRepository([[7, 201]]);
+    const user: Record<string, unknown> = {
+      _id: 7,
+      territory_id: 200,
+      operator_id: undefined,
+      scopes: territoryScopes,
+    };
+    const res = await invoke(repo, { session: mockSession(user), body: { territory_id: 201 } });
+    assertEquals(res.statusCode, 200);
+    assertEquals(res.body, { territory_id: 201, label: "AOM Deux Cent Un" });
+    // Tuple actif réécrit : territoire ciblé, opérateur purgé.
+    assertEquals(user.territory_id, 201);
+    assertEquals(user.operator_id, null);
+  });
+});


### PR DESCRIPTION
## Contexte

Tranche **T3** du chantier multi-SIRET/multi-périmètre (GEN-686). Stackée sur T2 (#3322).

## Contenu — bascule de contexte durcie

Route **`POST /auth/context { territory_id }`** :
- **401** si pas de session utilisateur (garde locale).
- **403** si l'utilisateur est de type opérateur (un seul scope ; seul le territoire bascule) — bloque aussi la **collision op/territoire** (scope `operator_id:42` ⇏ `territory_id:42`) **avant** tout appel DB.
- **Revalidation DB stricte** via `UserScopeRepository.userHasTerritory` — jamais contre `session.scopes[]` seul (anti-staleness/révocation). 403 si non accordé.
- Mutation du **tuple complet** (`territory_id` + `operator_id = null`) puis `session.save`.
- Réponse `{ territory_id, label }`.

## Tests

- Unit : 6 cas verts en local sur le handler exporté `contextRoute` (401 / bad request / refus opérateur / collision op-territoire sans appel DB / territoire non accordé / succès + mutation). La garantie DB stricte est couverte par `UserScopeRepository.integration.spec.ts` (T1).

## Note

La purge de session à la révocation (`SessionRepository`) est portée par **T4** (#3323), pas par cette route.
