### PR TITLE
feat(app-partners): bascule de périmètre + formulaire multi-scope (GEN-686) [T5/6]

### DIFF
--- a/app-partners/src/app/activite/campagnes/page.tsx
+++ b/app-partners/src/app/activite/campagnes/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { ActiveScopeBadge } from "@/components/common/ActiveScopeBadge";
 import Loading from "@/components/layout/Loading";
 import { useCampaignList, useTerritoriesList } from "@/hooks/api";
 import { useUrlSearch } from "@/hooks/useUrlSearch";
@@ -106,6 +107,9 @@ export default function TabCampaigns() {
 
   return (
     <>
+      <div className={fr.cx("fr-mb-2w")}>
+        <ActiveScopeBadge />
+      </div>
       {!campaignId && !user?.territory_id && (
         <div
           style={{

--- a/app-partners/src/app/activite/export/page.tsx
+++ b/app-partners/src/app/activite/export/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { ActiveScopeBadge } from "@/components/common/ActiveScopeBadge";
 import SelectGeo from "@/components/common/SelectGeo";
 import SelectTerritory from "@/components/common/SelectTerritory";
 import ExportList from "@/components/export/ExportList";
@@ -97,6 +98,9 @@ export default function TabExport() {
 
   return (
     <>
+      <div className={fr.cx("fr-mb-2w")}>
+        <ActiveScopeBadge />
+      </div>
       <Alert
         title={"Important"}
         severity="info"
@@ -218,6 +222,8 @@ export default function TabExport() {
                       title="Succès"
                       description={
                         <>
+                          <ActiveScopeBadge />
+                          <br />
                           Vous allez recevoir un email avec le lien de téléchargement d'ici maximum 2h.
                           <br />
                           Un rafraîchissement de la page sera nécessaire pour mettre à jour le statut de traitement de

--- a/app-partners/src/app/administration/tables/UsersTable.tsx
+++ b/app-partners/src/app/administration/tables/UsersTable.tsx
@@ -1,3 +1,4 @@
+import UserScopesEditor from "@/components/administration/UserScopesEditor";
 import AlertMessage from "@/components/common/AlertMessage";
 import { Modal } from "@/components/common/Modal";
 import Pagination from "@/components/common/Pagination";
@@ -6,7 +7,12 @@ import { useOperatorsList, useTerritoriesList, useUsersList } from "@/hooks/api"
 import { useActionsModal } from "@/hooks/useActionsModal";
 import { useUrlSearch } from "@/hooks/useUrlSearch";
 import { roles } from "@/interfaces/auth";
-import { UsersInterface, type OperatorsInterface, type TerritoriesInterface } from "@/interfaces/dataInterface";
+import {
+  UsersInterface,
+  type OperatorsInterface,
+  type TerritoriesInterface,
+  type UserScopeInput,
+} from "@/interfaces/dataInterface";
 import { useAuth } from "@/providers/AuthProvider";
 import { fr } from "@codegouvfr/react-dsfr";
 import Button from "@codegouvfr/react-dsfr/Button";
@@ -14,11 +20,11 @@ import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/Select";
 import Table from "@codegouvfr/react-dsfr/Table";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 
 export default function UsersTable(props: { title: string; territoryId: number | null; operatorId: number | null }) {
-  const { user, simulatedRole } = useAuth();
+  const { user, simulatedRole, setFormEditing } = useAuth();
   const [currentPage, setCurrentPage] = useState(1);
   const { search, debouncedSearch, onChangeSearch: setSearchValue } = useUrlSearch();
   const modal = useActionsModal<UsersInterface["data"][0]>();
@@ -30,6 +36,15 @@ export default function UsersTable(props: { title: string; territoryId: number |
     setSearchValue(search);
     setCurrentPage(1);
   };
+
+  // registry.admin seul manipule login_siren / octroi de scope (miroir de la permission back).
+  const canManageScopes = user?.role === "registry.admin";
+
+  // Garde-fou : signale une édition en cours pour la confirmation de bascule de périmètre.
+  useEffect(() => {
+    setFormEditing(modal.openModal && (modal.typeModal === "create" || modal.typeModal === "update"));
+    return () => setFormEditing(false);
+  }, [modal.openModal, modal.typeModal, setFormEditing]);
 
   const { data, refetch: refetchUsers } = useUsersList({
     territoryId: props.territoryId,
@@ -56,6 +71,20 @@ export default function UsersTable(props: { title: string; territoryId: number |
     return territoriesData?.data ?? [];
   };
 
+  // Périmètres initiaux d'une ligne (fallback sur la colonne legacy si l'API ne renvoie pas encore scopes).
+  const initialScopes = (row: Partial<UsersInterface["data"][0]>): UserScopeInput[] => {
+    if (row.scopes?.length) return row.scopes;
+    if (row.territory_id) return [{ territory_id: row.territory_id, is_default: true }];
+    return [];
+  };
+
+  // Suggestion login_siren = 9 premiers chiffres du SIRET du territoire par défaut.
+  const suggestSiren = (scopes: UserScopeInput[]): string => {
+    const def = scopes.find((s) => s.is_default) ?? scopes[0];
+    const siret = territoriesList().find((t) => t?._id === def?.territory_id)?.siret;
+    return siret ? siret.slice(0, 9) : "";
+  };
+
   const dataTable =
     data?.data?.map((d) => [
       d.firstname,
@@ -74,7 +103,7 @@ export default function UsersTable(props: { title: string; territoryId: number |
                   iconId: "fr-icon-refresh-line",
                   priority: "secondary",
                   onClick: () => {
-                    modal.setCurrentRow(d);
+                    modal.setCurrentRow({ ...d, scopes: initialScopes(d) });
                     modal.setErrors({});
                     modal.setOpenModal(true);
                     modal.setTypeModal("update");
@@ -96,7 +125,7 @@ export default function UsersTable(props: { title: string; territoryId: number |
                   iconId: "fr-icon-refresh-line",
                   priority: "secondary",
                   onClick: () => {
-                    modal.setCurrentRow(d);
+                    modal.setCurrentRow({ ...d, scopes: initialScopes(d) });
                     modal.setErrors({});
                     modal.setOpenModal(true);
                     modal.setTypeModal("update");
@@ -116,6 +145,18 @@ export default function UsersTable(props: { title: string; territoryId: number |
     operator_id: z.coerce.number({ message: "L'identifiant n'est pas un nombre" }).nullable(),
     territory_id: z.coerce.number({ message: "L'identifiant n'est pas un nombre" }).nullable(),
     role: z.enum(roles, { message: "Le rôle n'est pas valide" }),
+    login_siren: z
+      .union([z.string().regex(/^\d{9}$/, { message: "Le SIREN doit contenir 9 chiffres" }), z.literal(""), z.null()])
+      .optional(),
+    scopes: z
+      .array(
+        z.object({
+          territory_id: z.number().optional(),
+          operator_id: z.number().optional(),
+          is_default: z.boolean().optional(),
+        }),
+      )
+      .optional(),
   });
   const roleList = () => {
     if (simulatedRole) {
@@ -128,6 +169,22 @@ export default function UsersTable(props: { title: string; territoryId: number |
     }
     return getRolesList(user?.role ?? "anonymous");
   };
+
+  const currentRole = (modal.currentRow.role ?? "") as string;
+  const isOperatorTarget = currentRole.split(".")[0] === "operator" || !!user?.operator_id;
+  const isTerritoryTarget = currentRole.split(".")[0] === "territory" || !!user?.territory_id;
+
+  // Met à jour les périmètres, resynchronise territory_id (dual-write legacy) et suggère le SIREN si vide.
+  const onChangeScopes = (scopes: UserScopeInput[]) => {
+    const def = scopes.find((s) => s.is_default) ?? scopes[0];
+    modal.setCurrentRow((prev) => ({
+      ...prev,
+      scopes,
+      territory_id: def?.territory_id,
+      login_siren: (prev.login_siren as string) || suggestSiren(scopes),
+    }));
+  };
+
   return (
     <>
       {alert === "delete" && (
@@ -175,6 +232,7 @@ export default function UsersTable(props: { title: string; territoryId: number |
                 email: "",
                 operator_id: user?.operator_id ?? undefined,
                 territory_id: user?.territory_id ?? undefined,
+                scopes: user?.territory_id ? [{ territory_id: user.territory_id, is_default: true }] : [],
                 role: `${user?.role === "registry.admin" ? user?.role : `${user?.role.split(".")[0]}.user`}`,
               });
               modal.setOpenModal(true);
@@ -224,82 +282,100 @@ export default function UsersTable(props: { title: string; territoryId: number |
         <>
           {(modal.typeModal === "update" || modal.typeModal === "create") && (
             <>
-              <Input
-                label="Prénom"
-                state={modal.errors?.firstname ? "error" : "default"}
-                stateRelatedMessage={modal.errors?.firstname ?? ""}
-                nativeInputProps={{
-                  type: "text",
-                  value: (modal.currentRow.firstname as string) ?? "",
-                  onChange: (e) => modal.validateInputChange(formSchema, "firstname", e.target.value),
-                }}
-              />
-              <Input
-                label="Nom"
-                state={modal.errors?.lastname ? "error" : "default"}
-                stateRelatedMessage={modal.errors?.lastname ?? ""}
-                nativeInputProps={{
-                  type: "text",
-                  value: (modal.currentRow.lastname as string) ?? "",
-                  onChange: (e) => modal.validateInputChange(formSchema, "lastname", e.target.value),
-                }}
-              />
-              <Input
-                label="Adresse mail"
-                state={modal.errors?.email ? "error" : "default"}
-                stateRelatedMessage={modal.errors?.email ?? ""}
-                nativeInputProps={{
-                  type: "text",
-                  value: (modal.currentRow.email as string) ?? "",
-                  onChange: (e) => modal.validateInputChange(formSchema, "email", e.target.value),
-                }}
-              />
-              <Select
-                label="Rôle"
-                nativeSelectProps={{
-                  value: (modal.currentRow.role ?? "") as string,
-                  onChange: (e) => modal.validateInputChange(formSchema, "role", e.target.value),
-                }}
-              >
-                {roleList().map((r: string, i: number) => (
-                  <option key={i} value={r}>
-                    {labelRole(r)}
-                  </option>
-                ))}
-              </Select>
-              {((modal.currentRow.role && (modal.currentRow.role as string).split(".")[0] === "operator") ??
-                user?.operator_id) && (
+              <fieldset className={fr.cx("fr-fieldset")}>
+                <legend className={fr.cx("fr-fieldset__legend")}>Identité</legend>
+                <Input
+                  label="Prénom"
+                  state={modal.errors?.firstname ? "error" : "default"}
+                  stateRelatedMessage={modal.errors?.firstname ?? ""}
+                  nativeInputProps={{
+                    type: "text",
+                    value: (modal.currentRow.firstname as string) ?? "",
+                    onChange: (e) => modal.validateInputChange(formSchema, "firstname", e.target.value),
+                  }}
+                />
+                <Input
+                  label="Nom"
+                  state={modal.errors?.lastname ? "error" : "default"}
+                  stateRelatedMessage={modal.errors?.lastname ?? ""}
+                  nativeInputProps={{
+                    type: "text",
+                    value: (modal.currentRow.lastname as string) ?? "",
+                    onChange: (e) => modal.validateInputChange(formSchema, "lastname", e.target.value),
+                  }}
+                />
+                <Input
+                  label="Adresse mail"
+                  state={modal.errors?.email ? "error" : "default"}
+                  stateRelatedMessage={modal.errors?.email ?? ""}
+                  nativeInputProps={{
+                    type: "text",
+                    value: (modal.currentRow.email as string) ?? "",
+                    onChange: (e) => modal.validateInputChange(formSchema, "email", e.target.value),
+                  }}
+                />
                 <Select
-                  label="Opérateur"
+                  label="Rôle"
                   nativeSelectProps={{
-                    value: (modal.currentRow.operator_id as number) ?? undefined,
-                    onChange: (e) => modal.validateInputChange(formSchema, "operator_id", e.target.value),
+                    value: (modal.currentRow.role ?? "") as string,
+                    onChange: (e) => modal.validateInputChange(formSchema, "role", e.target.value),
                   }}
                 >
-                  {user?.role === "registry.admin" && <option value={undefined}>aucun</option>}
-                  {operatorsList().map((o, i) => (
-                    <option key={i} value={o?.id}>
-                      {o?.name}
+                  {roleList().map((r: string, i: number) => (
+                    <option key={i} value={r}>
+                      {labelRole(r)}
                     </option>
                   ))}
                 </Select>
+              </fieldset>
+
+              {/* Connexion : login_siren réservé registry.admin, masqué (pas grisé) sinon. */}
+              {canManageScopes && (
+                <fieldset className={fr.cx("fr-fieldset")}>
+                  <legend className={fr.cx("fr-fieldset__legend")}>Connexion</legend>
+                  <Input
+                    label="SIREN de connexion (ProConnect)"
+                    hintText="9 chiffres — distinct du SIRET du territoire"
+                    state={modal.errors?.login_siren ? "error" : "default"}
+                    stateRelatedMessage={modal.errors?.login_siren ?? ""}
+                    nativeInputProps={{
+                      inputMode: "numeric",
+                      maxLength: 9,
+                      value: (modal.currentRow.login_siren as string) ?? suggestSiren((modal.currentRow.scopes as UserScopeInput[]) ?? []),
+                      onChange: (e) => modal.validateInputChange(formSchema, "login_siren", e.target.value),
+                    }}
+                  />
+                </fieldset>
               )}
-              {((modal.currentRow.role && (modal.currentRow.role as string).split(".")[0] === "territory") ??
-                user?.territory_id) && (
-                <Select
-                  label="Territoire"
-                  nativeSelectProps={{
-                    value: (modal.currentRow.territory_id as number) ?? undefined,
-                    onChange: (e) => modal.validateInputChange(formSchema, "territory_id", e.target.value),
-                  }}
-                >
-                  {user?.role === "registry.admin" && <option value={undefined}>aucun</option>}
-                  {territoriesList().map((t, i) => (
-                    <option key={i} value={t?._id}>
-                      {t?.name}
-                    </option>
-                  ))}
-                </Select>
+
+              {/* Périmètres : masqués pour territory.admin ; opérateur = Select unique, territoire = table éditable. */}
+              {(canManageScopes || isOperatorTarget) && (
+                <fieldset className={fr.cx("fr-fieldset")}>
+                  <legend className={fr.cx("fr-fieldset__legend")}>Périmètres</legend>
+                  {isOperatorTarget && (
+                    <Select
+                      label="Opérateur"
+                      nativeSelectProps={{
+                        value: (modal.currentRow.operator_id as number) ?? undefined,
+                        onChange: (e) => modal.validateInputChange(formSchema, "operator_id", e.target.value),
+                      }}
+                    >
+                      {canManageScopes && <option value={undefined}>aucun</option>}
+                      {operatorsList().map((o, i) => (
+                        <option key={i} value={o?.id}>
+                          {o?.name}
+                        </option>
+                      ))}
+                    </Select>
+                  )}
+                  {canManageScopes && isTerritoryTarget && !isOperatorTarget && (
+                    <UserScopesEditor
+                      scopes={(modal.currentRow.scopes as UserScopeInput[]) ?? []}
+                      territories={territoriesList()}
+                      onChange={onChangeScopes}
+                    />
+                  )}
+                </fieldset>
               )}
             </>
           )}

--- a/app-partners/src/app/administration/tables/UsersTable.tsx
+++ b/app-partners/src/app/administration/tables/UsersTable.tsx
@@ -1,3 +1,4 @@
+import UserScopesEditor from "@/components/administration/UserScopesEditor";
 import AlertMessage from "@/components/common/AlertMessage";
 import { Modal } from "@/components/common/Modal";
 import Pagination from "@/components/common/Pagination";
@@ -6,7 +7,12 @@ import { useOperatorsList, useTerritoriesList, useUsersList } from "@/hooks/api"
 import { useActionsModal } from "@/hooks/useActionsModal";
 import { useUrlSearch } from "@/hooks/useUrlSearch";
 import { roles } from "@/interfaces/auth";
-import { UsersInterface, type OperatorsInterface, type TerritoriesInterface } from "@/interfaces/dataInterface";
+import {
+  UsersInterface,
+  type OperatorsInterface,
+  type TerritoriesInterface,
+  type UserScopeInput,
+} from "@/interfaces/dataInterface";
 import { useAuth } from "@/providers/AuthProvider";
 import { fr } from "@codegouvfr/react-dsfr";
 import Button from "@codegouvfr/react-dsfr/Button";
@@ -14,11 +20,11 @@ import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/Select";
 import Table from "@codegouvfr/react-dsfr/Table";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 
 export default function UsersTable(props: { title: string; territoryId: number | null; operatorId: number | null }) {
-  const { user, simulatedRole } = useAuth();
+  const { user, simulatedRole, setFormEditing } = useAuth();
   const [currentPage, setCurrentPage] = useState(1);
   const { search, debouncedSearch, onChangeSearch: setSearchValue } = useUrlSearch();
   const modal = useActionsModal<UsersInterface["data"][0]>();
@@ -30,6 +36,15 @@ export default function UsersTable(props: { title: string; territoryId: number |
     setSearchValue(search);
     setCurrentPage(1);
   };
+
+  // registry.admin seul manipule login_siren / octroi de scope (miroir de la permission back).
+  const canManageScopes = user?.role === "registry.admin";
+
+  // Garde-fou : signale une édition en cours pour la confirmation de bascule de périmètre.
+  useEffect(() => {
+    setFormEditing(modal.openModal && (modal.typeModal === "create" || modal.typeModal === "update"));
+    return () => setFormEditing(false);
+  }, [modal.openModal, modal.typeModal, setFormEditing]);
 
   const { data, refetch: refetchUsers } = useUsersList({
     territoryId: props.territoryId,
@@ -48,12 +63,32 @@ export default function UsersTable(props: { title: string; territoryId: number |
     }
     return operatorsData?.data ?? [];
   };
-  const { data: territoriesData, refetch: refetchTerritories } = useTerritoriesList({ limit: 200 });
-  const territoriesList = () => {
-    if (user?.territory_id) {
-      return [territoriesData?.data.find((t) => t._id === user?.territory_id)] as TerritoriesInterface["data"];
-    }
-    return territoriesData?.data ?? [];
+  // Limite large : la modale doit résoudre le nom de tous les territoires, l'Autocomplete filtre en local.
+  const { data: territoriesData, refetch: refetchTerritories } = useTerritoriesList({ limit: 1000 });
+  // Liste complète : un registry.admin porteur d'un scope a un territory_id sans être limité à ce territoire.
+  const territoriesList = (): TerritoriesInterface["data"] => territoriesData?.data ?? [];
+
+  // Périmètres initiaux d'une ligne (fallback sur la colonne legacy si l'API ne renvoie pas encore scopes).
+  const initialScopes = (row: Partial<UsersInterface["data"][0]>): UserScopeInput[] => {
+    if (row.scopes?.length) return row.scopes;
+    if (row.territory_id) return [{ territory_id: row.territory_id, is_default: true }];
+    return [];
+  };
+
+  // Suggestion login_siren = 9 premiers chiffres du SIRET du territoire par défaut.
+  const suggestSiren = (scopes: UserScopeInput[]): string => {
+    const def = scopes.find((s) => s.is_default) ?? scopes[0];
+    const siret = territoriesList().find((t) => t?._id === def?.territory_id)?.siret;
+    return siret ? siret.slice(0, 9) : "";
+  };
+
+  // La suggestion doit être semée dans currentRow : le PUT ne sérialise que ce qui y est écrit.
+  const openUpdateModal = (row: UsersInterface["data"][0]) => {
+    const scopes = initialScopes(row);
+    modal.setCurrentRow({ ...row, scopes, login_siren: row.login_siren ?? suggestSiren(scopes) });
+    modal.setErrors({});
+    modal.setOpenModal(true);
+    modal.setTypeModal("update");
   };
 
   const dataTable =
@@ -73,12 +108,7 @@ export default function UsersTable(props: { title: string; territoryId: number |
                   children: "modifier",
                   iconId: "fr-icon-refresh-line",
                   priority: "secondary",
-                  onClick: () => {
-                    modal.setCurrentRow(d);
-                    modal.setErrors({});
-                    modal.setOpenModal(true);
-                    modal.setTypeModal("update");
-                  },
+                  onClick: () => openUpdateModal(d),
                 },
                 {
                   children: "supprimer",
@@ -95,12 +125,7 @@ export default function UsersTable(props: { title: string; territoryId: number |
                   children: "modifier",
                   iconId: "fr-icon-refresh-line",
                   priority: "secondary",
-                  onClick: () => {
-                    modal.setCurrentRow(d);
-                    modal.setErrors({});
-                    modal.setOpenModal(true);
-                    modal.setTypeModal("update");
-                  },
+                  onClick: () => openUpdateModal(d),
                 },
               ]
         }
@@ -116,6 +141,18 @@ export default function UsersTable(props: { title: string; territoryId: number |
     operator_id: z.coerce.number({ message: "L'identifiant n'est pas un nombre" }).nullable(),
     territory_id: z.coerce.number({ message: "L'identifiant n'est pas un nombre" }).nullable(),
     role: z.enum(roles, { message: "Le rôle n'est pas valide" }),
+    login_siren: z
+      .union([z.string().regex(/^\d{9}$/, { message: "Le SIREN doit contenir 9 chiffres" }), z.literal(""), z.null()])
+      .optional(),
+    scopes: z
+      .array(
+        z.object({
+          territory_id: z.number().optional(),
+          operator_id: z.number().optional(),
+          is_default: z.boolean().optional(),
+        }),
+      )
+      .optional(),
   });
   const roleList = () => {
     if (simulatedRole) {
@@ -128,6 +165,23 @@ export default function UsersTable(props: { title: string; territoryId: number |
     }
     return getRolesList(user?.role ?? "anonymous");
   };
+
+  // Type de formulaire décidé par le rôle de l'utilisateur édité, jamais par le contexte de l'admin connecté.
+  const targetScopeType = ((modal.currentRow.role ?? "") as string).split(".")[0];
+  const isOperatorTarget = targetScopeType === "operator";
+  const isTerritoryTarget = targetScopeType === "territory";
+
+  // Met à jour les périmètres, resynchronise territory_id (dual-write legacy) et suggère le SIREN si vide.
+  const onChangeScopes = (scopes: UserScopeInput[]) => {
+    const def = scopes.find((s) => s.is_default) ?? scopes[0];
+    modal.setCurrentRow((prev) => ({
+      ...prev,
+      scopes,
+      territory_id: def?.territory_id,
+      login_siren: (prev.login_siren as string) || suggestSiren(scopes),
+    }));
+  };
+
   return (
     <>
       {alert === "delete" && (
@@ -169,12 +223,17 @@ export default function UsersTable(props: { title: string; territoryId: number |
           <Button
             iconId="fr-icon-add-circle-line"
             onClick={() => {
+              const scopes: UserScopeInput[] = user?.territory_id
+                ? [{ territory_id: user.territory_id, is_default: true }]
+                : [];
               modal.setCurrentRow({
                 firstname: "",
                 lastname: "",
                 email: "",
                 operator_id: user?.operator_id ?? undefined,
                 territory_id: user?.territory_id ?? undefined,
+                scopes,
+                login_siren: suggestSiren(scopes),
                 role: `${user?.role === "registry.admin" ? user?.role : `${user?.role.split(".")[0]}.user`}`,
               });
               modal.setOpenModal(true);
@@ -224,82 +283,100 @@ export default function UsersTable(props: { title: string; territoryId: number |
         <>
           {(modal.typeModal === "update" || modal.typeModal === "create") && (
             <>
-              <Input
-                label="Prénom"
-                state={modal.errors?.firstname ? "error" : "default"}
-                stateRelatedMessage={modal.errors?.firstname ?? ""}
-                nativeInputProps={{
-                  type: "text",
-                  value: (modal.currentRow.firstname as string) ?? "",
-                  onChange: (e) => modal.validateInputChange(formSchema, "firstname", e.target.value),
-                }}
-              />
-              <Input
-                label="Nom"
-                state={modal.errors?.lastname ? "error" : "default"}
-                stateRelatedMessage={modal.errors?.lastname ?? ""}
-                nativeInputProps={{
-                  type: "text",
-                  value: (modal.currentRow.lastname as string) ?? "",
-                  onChange: (e) => modal.validateInputChange(formSchema, "lastname", e.target.value),
-                }}
-              />
-              <Input
-                label="Adresse mail"
-                state={modal.errors?.email ? "error" : "default"}
-                stateRelatedMessage={modal.errors?.email ?? ""}
-                nativeInputProps={{
-                  type: "text",
-                  value: (modal.currentRow.email as string) ?? "",
-                  onChange: (e) => modal.validateInputChange(formSchema, "email", e.target.value),
-                }}
-              />
-              <Select
-                label="Rôle"
-                nativeSelectProps={{
-                  value: (modal.currentRow.role ?? "") as string,
-                  onChange: (e) => modal.validateInputChange(formSchema, "role", e.target.value),
-                }}
-              >
-                {roleList().map((r: string, i: number) => (
-                  <option key={i} value={r}>
-                    {labelRole(r)}
-                  </option>
-                ))}
-              </Select>
-              {((modal.currentRow.role && (modal.currentRow.role as string).split(".")[0] === "operator") ??
-                user?.operator_id) && (
+              <fieldset className={fr.cx("fr-fieldset")}>
+                <legend className={fr.cx("fr-fieldset__legend")}>Identité</legend>
+                <Input
+                  label="Prénom"
+                  state={modal.errors?.firstname ? "error" : "default"}
+                  stateRelatedMessage={modal.errors?.firstname ?? ""}
+                  nativeInputProps={{
+                    type: "text",
+                    value: (modal.currentRow.firstname as string) ?? "",
+                    onChange: (e) => modal.validateInputChange(formSchema, "firstname", e.target.value),
+                  }}
+                />
+                <Input
+                  label="Nom"
+                  state={modal.errors?.lastname ? "error" : "default"}
+                  stateRelatedMessage={modal.errors?.lastname ?? ""}
+                  nativeInputProps={{
+                    type: "text",
+                    value: (modal.currentRow.lastname as string) ?? "",
+                    onChange: (e) => modal.validateInputChange(formSchema, "lastname", e.target.value),
+                  }}
+                />
+                <Input
+                  label="Adresse mail"
+                  state={modal.errors?.email ? "error" : "default"}
+                  stateRelatedMessage={modal.errors?.email ?? ""}
+                  nativeInputProps={{
+                    type: "text",
+                    value: (modal.currentRow.email as string) ?? "",
+                    onChange: (e) => modal.validateInputChange(formSchema, "email", e.target.value),
+                  }}
+                />
                 <Select
-                  label="Opérateur"
+                  label="Rôle"
                   nativeSelectProps={{
-                    value: (modal.currentRow.operator_id as number) ?? undefined,
-                    onChange: (e) => modal.validateInputChange(formSchema, "operator_id", e.target.value),
+                    value: (modal.currentRow.role ?? "") as string,
+                    onChange: (e) => modal.validateInputChange(formSchema, "role", e.target.value),
                   }}
                 >
-                  {user?.role === "registry.admin" && <option value={undefined}>aucun</option>}
-                  {operatorsList().map((o, i) => (
-                    <option key={i} value={o?.id}>
-                      {o?.name}
+                  {roleList().map((r: string, i: number) => (
+                    <option key={i} value={r}>
+                      {labelRole(r)}
                     </option>
                   ))}
                 </Select>
+              </fieldset>
+
+              {/* Connexion : login_siren réservé registry.admin, masqué (pas grisé) sinon. */}
+              {canManageScopes && (
+                <fieldset className={fr.cx("fr-fieldset")}>
+                  <legend className={fr.cx("fr-fieldset__legend")}>Connexion</legend>
+                  <Input
+                    label="SIREN de connexion (ProConnect)"
+                    hintText="9 chiffres — distinct du SIRET du territoire"
+                    state={modal.errors?.login_siren ? "error" : "default"}
+                    stateRelatedMessage={modal.errors?.login_siren ?? ""}
+                    nativeInputProps={{
+                      inputMode: "numeric",
+                      maxLength: 9,
+                      value: (modal.currentRow.login_siren as string) ?? "",
+                      onChange: (e) => modal.validateInputChange(formSchema, "login_siren", e.target.value),
+                    }}
+                  />
+                </fieldset>
               )}
-              {((modal.currentRow.role && (modal.currentRow.role as string).split(".")[0] === "territory") ??
-                user?.territory_id) && (
-                <Select
-                  label="Territoire"
-                  nativeSelectProps={{
-                    value: (modal.currentRow.territory_id as number) ?? undefined,
-                    onChange: (e) => modal.validateInputChange(formSchema, "territory_id", e.target.value),
-                  }}
-                >
-                  {user?.role === "registry.admin" && <option value={undefined}>aucun</option>}
-                  {territoriesList().map((t, i) => (
-                    <option key={i} value={t?._id}>
-                      {t?.name}
-                    </option>
-                  ))}
-                </Select>
+
+              {/* Périmètres : masqués pour territory.admin ; opérateur = Select unique, territoire = table éditable. */}
+              {(canManageScopes || isOperatorTarget) && (
+                <fieldset className={fr.cx("fr-fieldset")}>
+                  <legend className={fr.cx("fr-fieldset__legend")}>Périmètres</legend>
+                  {isOperatorTarget && (
+                    <Select
+                      label="Opérateur"
+                      nativeSelectProps={{
+                        value: (modal.currentRow.operator_id as number) ?? undefined,
+                        onChange: (e) => modal.validateInputChange(formSchema, "operator_id", e.target.value),
+                      }}
+                    >
+                      {canManageScopes && <option value={undefined}>aucun</option>}
+                      {operatorsList().map((o, i) => (
+                        <option key={i} value={o?.id}>
+                          {o?.name}
+                        </option>
+                      ))}
+                    </Select>
+                  )}
+                  {canManageScopes && isTerritoryTarget && !isOperatorTarget && (
+                    <UserScopesEditor
+                      scopes={(modal.currentRow.scopes as UserScopeInput[]) ?? []}
+                      territories={territoriesList()}
+                      onChange={onChangeScopes}
+                    />
+                  )}
+                </fieldset>
               )}
             </>
           )}

--- a/app-partners/src/app/layout.tsx
+++ b/app-partners/src/app/layout.tsx
@@ -44,9 +44,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body>
-        <AuthProvider>
-          <DsfrProvider>
-            <MuiDsfrThemeProvider>
+        <DsfrProvider>
+          <MuiDsfrThemeProvider>
+            <AuthProvider>
               <Skiplinks />
               <AppHeader />
               <main tabIndex={-1}>
@@ -55,12 +55,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <Follow />
               </main>
               <AppFooter />
-            </MuiDsfrThemeProvider>
-          </DsfrProvider>
-          <Suspense fallback={null}>
-            <MatomoAnalytics />
-          </Suspense>
-        </AuthProvider>
+              <Suspense fallback={null}>
+                <MatomoAnalytics />
+              </Suspense>
+            </AuthProvider>
+          </MuiDsfrThemeProvider>
+        </DsfrProvider>
       </body>
     </html>
   );

--- a/app-partners/src/components/administration/UserScopesEditor.tsx
+++ b/app-partners/src/components/administration/UserScopesEditor.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { type Territory } from "@/interfaces/dataInterface";
+import { type UserScopeInput } from "@/interfaces/dataInterface";
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Table from "@codegouvfr/react-dsfr/Table";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+import { useState } from "react";
+
+// Édition des périmètres territoire d'un user : liste + radio défaut + ajout (registry.admin).
+export default function UserScopesEditor(props: {
+  scopes: UserScopeInput[];
+  territories: Territory[];
+  onChange: (scopes: UserScopeInput[]) => void;
+}) {
+  const { scopes, territories, onChange } = props;
+  const [toAdd, setToAdd] = useState<Territory | null>(null);
+
+  const nameOf = (territory_id?: number) => territories.find((t) => t._id === territory_id)?.name ?? territory_id;
+
+  const setDefault = (territory_id?: number) => {
+    onChange(scopes.map((s) => ({ ...s, is_default: s.territory_id === territory_id })));
+  };
+
+  const remove = (territory_id?: number) => {
+    const next = scopes.filter((s) => s.territory_id !== territory_id);
+    // Retrait du défaut : promotion automatique du premier périmètre restant.
+    if (next.length > 0 && !next.some((s) => s.is_default)) {
+      next[0].is_default = true;
+    }
+    onChange(next);
+  };
+
+  const add = (territory: Territory | null) => {
+    if (!territory?._id || scopes.some((s) => s.territory_id === territory._id)) return;
+    onChange([...scopes, { territory_id: territory._id, is_default: scopes.length === 0 }]);
+    setToAdd(null);
+  };
+
+  const rows = scopes.map((s) => [
+    nameOf(s.territory_id),
+    <input
+      key={`def-${s.territory_id}`}
+      type="radio"
+      name="scope-default"
+      aria-label={`Périmètre par défaut : ${String(nameOf(s.territory_id))}`}
+      checked={!!s.is_default}
+      onChange={() => setDefault(s.territory_id)}
+    />,
+    <Button
+      key={`rm-${s.territory_id}`}
+      iconId="fr-icon-delete-bin-line"
+      priority="tertiary no outline"
+      size="small"
+      title="Retirer le périmètre"
+      disabled={scopes.length <= 1}
+      onClick={() => remove(s.territory_id)}
+    >
+      Retirer
+    </Button>,
+  ]);
+
+  const options = territories.filter((t) => !scopes.some((s) => s.territory_id === t._id));
+
+  return (
+    <div className={fr.cx("fr-mt-2w")}>
+      <Table data={rows} headers={["Territoire", "Défaut", "Action"]} fixed />
+      <Autocomplete
+        id="add-scope"
+        size="small"
+        options={options}
+        value={toAdd}
+        getOptionLabel={(o) => o.name}
+        isOptionEqualToValue={(o, v) => o._id === v._id}
+        noOptionsText="Aucun territoire"
+        onChange={(e, v) => add(v)}
+        renderInput={(params) => <TextField {...params} label="Ajouter un périmètre" />}
+      />
+    </div>
+  );
+}

--- a/app-partners/src/components/administration/UserScopesEditor.tsx
+++ b/app-partners/src/components/administration/UserScopesEditor.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { type Territory } from "@/interfaces/dataInterface";
+import { type UserScopeInput } from "@/interfaces/dataInterface";
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Table from "@codegouvfr/react-dsfr/Table";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+import { useState } from "react";
+
+// Édition des périmètres territoire d'un user : liste + radio défaut + ajout (registry.admin).
+export default function UserScopesEditor(props: {
+  scopes: UserScopeInput[];
+  territories: Territory[];
+  onChange: (scopes: UserScopeInput[]) => void;
+}) {
+  const { scopes, territories, onChange } = props;
+  const [toAdd, setToAdd] = useState<Territory | null>(null);
+
+  const nameOf = (territory_id?: number) => territories.find((t) => t?._id === territory_id)?.name ?? territory_id;
+
+  const setDefault = (territory_id?: number) => {
+    onChange(scopes.map((s) => ({ ...s, is_default: s.territory_id === territory_id })));
+  };
+
+  const remove = (territory_id?: number) => {
+    const next = scopes.filter((s) => s.territory_id !== territory_id);
+    // Retrait du défaut : promotion du premier restant, sans muter les objets partagés avec la ligne en cache.
+    if (next.length > 0 && !next.some((s) => s.is_default)) {
+      return onChange(next.map((s, i) => ({ ...s, is_default: i === 0 })));
+    }
+    onChange(next);
+  };
+
+  const add = (territory: Territory | null) => {
+    if (!territory?._id || scopes.some((s) => s.territory_id === territory._id)) return;
+    onChange([...scopes, { territory_id: territory._id, is_default: scopes.length === 0 }]);
+    setToAdd(null);
+  };
+
+  const rows = scopes.map((s) => [
+    nameOf(s.territory_id),
+    <input
+      key={`def-${s.territory_id}`}
+      type="radio"
+      name="scope-default"
+      aria-label={`Périmètre par défaut : ${String(nameOf(s.territory_id))}`}
+      checked={!!s.is_default}
+      onChange={() => setDefault(s.territory_id)}
+    />,
+    <Button
+      key={`rm-${s.territory_id}`}
+      iconId="fr-icon-delete-bin-line"
+      priority="tertiary no outline"
+      size="small"
+      title="Retirer le périmètre"
+      disabled={scopes.length <= 1}
+      onClick={() => remove(s.territory_id)}
+    >
+      Retirer
+    </Button>,
+  ]);
+
+  const options = territories.filter((t) => t?._id && !scopes.some((s) => s.territory_id === t._id));
+
+  return (
+    <div className={fr.cx("fr-mt-2w")}>
+      <Table data={rows} headers={["Territoire", "Défaut", "Action"]} fixed />
+      <Autocomplete
+        id="add-scope"
+        size="small"
+        options={options}
+        value={toAdd}
+        getOptionLabel={(o) => o?.name ?? ""}
+        isOptionEqualToValue={(o, v) => o?._id === v?._id}
+        noOptionsText="Aucun territoire"
+        onChange={(e, v) => add(v)}
+        renderInput={(params) => <TextField {...params} label="Ajouter un périmètre" />}
+      />
+    </div>
+  );
+}

--- a/app-partners/src/components/auth/ProfilButton.tsx
+++ b/app-partners/src/components/auth/ProfilButton.tsx
@@ -1,11 +1,12 @@
 "use client";
-import { labelRole } from "@/helpers/auth";
+import { activeScopeLabel, labelRole } from "@/helpers/auth";
 import { useAuth } from "@/providers/AuthProvider";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Tag from "@codegouvfr/react-dsfr/Tag";
 
 export function ProfilButton() {
   const { isAuth, user } = useAuth();
+  const scopeLabel = activeScopeLabel(user);
 
   return (
     <>
@@ -20,8 +21,7 @@ export function ProfilButton() {
             <div style={{ display: "block" }}>
               <div>{user?.name}</div>
               <div>{labelRole(user?.role ?? "")}</div>
-              {user?.territory_id && <Tag>Territoire : {user.territory_id}</Tag>}
-              {user?.operator_id && <Tag>Opérateur : {user.operator_id}</Tag>}
+              {scopeLabel && <Tag>{scopeLabel}</Tag>}
             </div>
           </Button>
         </>

--- a/app-partners/src/components/auth/ScopeSwitcher.tsx
+++ b/app-partners/src/components/auth/ScopeSwitcher.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { type UserScope } from "@/interfaces/auth";
+import { useAuth } from "@/providers/AuthProvider";
+import { fr } from "@codegouvfr/react-dsfr";
+import Badge from "@codegouvfr/react-dsfr/Badge";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+
+// Sélecteur du périmètre actif dans le header (bascule serveur réelle, pas le mode simulate).
+export function ScopeSwitcher() {
+  const { isAuth, scopes, activeScope, switchScope } = useAuth();
+  if (!isAuth) return null;
+
+  // Seuls les territoires sont basculables (opérateur = 1:1).
+  const territoryScopes = scopes.filter((s) => s.territory_id);
+
+  // 0 ou 1 périmètre basculable : badge statique, pas de menu.
+  if (territoryScopes.length <= 1) {
+    if (!activeScope) return null;
+    return (
+      <Badge as="span" severity="info" noIcon>
+        {activeScope.label}
+      </Badge>
+    );
+  }
+
+  return (
+    <Autocomplete
+      id="scope-switcher"
+      size="small"
+      disableClearable
+      options={territoryScopes}
+      value={activeScope}
+      isOptionEqualToValue={(o, v) => o.territory_id === v.territory_id}
+      getOptionLabel={(option) => option.label}
+      noOptionsText="Aucun périmètre"
+      renderOption={(props, option) => {
+        const isActive = option.territory_id === activeScope?.territory_id;
+        return (
+          <li {...props} key={option.territory_id}>
+            <span className={fr.cx(isActive ? "fr-text--bold" : undefined)}>
+              {isActive ? "✓ " : ""}
+              {option.label}
+            </span>
+          </li>
+        );
+      }}
+      onChange={(e, v: UserScope | null) => {
+        if (v?.territory_id) void switchScope(v.territory_id);
+      }}
+      renderInput={(params) => <TextField {...params} label="Périmètre actif" />}
+      sx={{ minWidth: 240 }}
+    />
+  );
+}

--- a/app-partners/src/components/auth/ScopeSwitcher.tsx
+++ b/app-partners/src/components/auth/ScopeSwitcher.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { type UserScope } from "@/interfaces/auth";
+import { useAuth } from "@/providers/AuthProvider";
+import { fr } from "@codegouvfr/react-dsfr";
+import Badge from "@codegouvfr/react-dsfr/Badge";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
+
+// Sélecteur du périmètre actif dans le header (bascule serveur réelle, pas le mode simulate).
+export function ScopeSwitcher() {
+  const { isAuth, scopes, activeScope, switchScope } = useAuth();
+  if (!isAuth) return null;
+
+  // Seuls les territoires sont basculables (opérateur = 1:1).
+  const territoryScopes = scopes.filter((s) => s.territory_id);
+
+  // 0 ou 1 périmètre basculable : badge statique, pas de menu.
+  if (territoryScopes.length <= 1) {
+    if (!activeScope) return null;
+    return (
+      <Badge as="span" severity="info" noIcon>
+        {activeScope.label}
+      </Badge>
+    );
+  }
+
+  // Tuple de session hors des scopes connus (transitoire) : rien à contrôler, checkAuth réaligne.
+  if (!activeScope) return null;
+
+  return (
+    <Autocomplete
+      id="scope-switcher"
+      size="small"
+      disableClearable
+      options={territoryScopes}
+      value={activeScope}
+      isOptionEqualToValue={(o, v) => o.territory_id === v.territory_id}
+      getOptionLabel={(option) => option.label}
+      noOptionsText="Aucun périmètre"
+      renderOption={(props, option) => {
+        const isActive = option.territory_id === activeScope?.territory_id;
+        return (
+          <li {...props} key={option.territory_id}>
+            <span className={fr.cx(isActive ? "fr-text--bold" : undefined)}>
+              {isActive ? "✓ " : ""}
+              {option.label}
+            </span>
+          </li>
+        );
+      }}
+      onChange={(e, v: UserScope | null) => {
+        // L'échec de bascule est déjà remonté en toast par switchScope.
+        if (v?.territory_id) switchScope(v.territory_id).catch(() => undefined);
+      }}
+      renderInput={(params) => <TextField {...params} label="Périmètre actif" />}
+      sx={{ minWidth: 240 }}
+    />
+  );
+}

--- a/app-partners/src/components/common/ActiveScopeBadge.tsx
+++ b/app-partners/src/components/common/ActiveScopeBadge.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { activeScopeLabel } from "@/helpers/auth";
+import { useAuth } from "@/providers/AuthProvider";
+import Badge from "@codegouvfr/react-dsfr/Badge";
+
+// Rappel du périmètre actif au point d'action (export, campagnes, confirmation).
+export function ActiveScopeBadge() {
+  const { user } = useAuth();
+  const label = activeScopeLabel(user);
+  if (!label) return null;
+  return (
+    <Badge as="span" severity="info" noIcon>
+      Périmètre actif : {label}
+    </Badge>
+  );
+}

--- a/app-partners/src/components/layout/AppHeader.tsx
+++ b/app-partners/src/components/layout/AppHeader.tsx
@@ -1,5 +1,6 @@
 import { AuthButton } from "@/components/auth/AuthButton";
 import { ProfilButton } from "@/components/auth/ProfilButton";
+import { ScopeSwitcher } from "@/components/auth/ScopeSwitcher";
 import { Header } from "@codegouvfr/react-dsfr/Header";
 import Navigation from "./Navigation";
 
@@ -26,6 +27,7 @@ export function AppHeader() {
       serviceTagline="Ensemble, accélérons le covoiturage quotidien"
       navigation={<Navigation />}
       quickAccessItems={[
+        <ScopeSwitcher key="scope-switcher" />,
         <ProfilButton key="profil-button" />,
         <AuthButton key="auth-button" />,
       ]}

--- a/app-partners/src/helpers/auth.ts
+++ b/app-partners/src/helpers/auth.ts
@@ -1,10 +1,13 @@
 import { Config } from "@/config";
 import {
+  ADMIN_SCOPE_LABEL,
   type AuthContextProps,
   type Role,
   type RoleKind,
   type RoleLevel,
   roles,
+  type UserInterface,
+  type UserScope,
 } from "@/interfaces/auth";
 import crypto from "crypto";
 
@@ -84,6 +87,36 @@ export const getUserSession = async () => {
     credentials: "include",
   });
   return (await response.json()) as AuthContextProps["user"];
+};
+
+// Bascule le périmètre actif côté serveur ; renvoie le contexte confirmé.
+export const postAuthContext = async (territory_id: number) => {
+  const response = await fetch(`${Config.get<string>("auth.domain")}/auth/context`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ territory_id }),
+  });
+  if (!response.ok) {
+    throw new Error(response.status === 403 ? "Périmètre non autorisé" : "Bascule de périmètre impossible");
+  }
+  return (await response.json()) as { territory_id: number; label: string };
+};
+
+// Périmètre actif = scope dont l'id correspond au tuple actif de session.
+export const getActiveScope = (user?: UserInterface): UserScope | undefined => {
+  if (!user?.scopes?.length) return undefined;
+  return user.scopes.find((s) =>
+    user.operator_id ? s.operator_id === user.operator_id : s.territory_id === user.territory_id,
+  );
+};
+
+// Libellé affichable du périmètre actif (jamais l'ID brut).
+export const activeScopeLabel = (user?: UserInterface): string => {
+  const scope = getActiveScope(user);
+  if (scope) return scope.label;
+  if (user?.role === "registry.admin") return ADMIN_SCOPE_LABEL;
+  return user?.organisation ?? user?.name ?? "";
 };
 
 export function splitRole(role: unknown): [RoleKind, RoleLevel] {

--- a/app-partners/src/helpers/auth.ts
+++ b/app-partners/src/helpers/auth.ts
@@ -1,10 +1,13 @@
 import { Config } from "@/config";
 import {
+  ADMIN_SCOPE_LABEL,
   type AuthContextProps,
   type Role,
   type RoleKind,
   type RoleLevel,
   roles,
+  type UserInterface,
+  type UserScope,
 } from "@/interfaces/auth";
 import crypto from "crypto";
 
@@ -84,6 +87,37 @@ export const getUserSession = async () => {
     credentials: "include",
   });
   return (await response.json()) as AuthContextProps["user"];
+};
+
+// Bascule le périmètre actif côté serveur ; renvoie le contexte confirmé.
+export const postAuthContext = async (territory_id: number) => {
+  const response = await fetch(`${Config.get<string>("auth.domain")}/auth/context`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ territory_id }),
+  });
+  if (!response.ok) {
+    throw new Error(response.status === 403 ? "Périmètre non autorisé" : "Bascule de périmètre impossible");
+  }
+  return (await response.json()) as { territory_id: number; label: string };
+};
+
+// Périmètre actif = scope dont l'id correspond au tuple actif de session.
+export const getActiveScope = (user?: UserInterface): UserScope | undefined => {
+  if (!user?.scopes?.length) return undefined;
+  return user.scopes.find((s) =>
+    user.operator_id ? s.operator_id === user.operator_id : s.territory_id === user.territory_id,
+  );
+};
+
+// Libellé affichable du périmètre actif (jamais l'ID brut).
+export const activeScopeLabel = (user?: UserInterface): string => {
+  const scope = getActiveScope(user);
+  if (scope) return scope.label;
+  if (user?.role === "registry.admin") return ADMIN_SCOPE_LABEL;
+  // Le nom de la personne n'est pas un périmètre : pas de repli dessus.
+  return user?.organisation ?? "";
 };
 
 export function splitRole(role: unknown): [RoleKind, RoleLevel] {

--- a/app-partners/src/interfaces/auth.ts
+++ b/app-partners/src/interfaces/auth.ts
@@ -1,3 +1,11 @@
+// Périmètre autorisé d'un utilisateur (opérateur XOR territoire).
+export interface UserScope {
+  operator_id?: number;
+  territory_id?: number;
+  label: string;
+  siret?: string;
+}
+
 export interface UserInterface {
   email: string;
   name?: string;
@@ -6,6 +14,8 @@ export interface UserInterface {
   operator_id: number | null;
   territory_id: number | null;
   siret?: string;
+  login_siren?: string | null;
+  scopes?: UserScope[];
   analytics_id?: string;
   organisation?: string;
 }
@@ -14,14 +24,23 @@ export interface AuthContextProps {
   isAuth: boolean;
   setIsAuth: (newIsAuth: boolean) => void;
   user?: UserInterface;
+  scopes: UserScope[];
+  activeScope?: UserScope;
   simulate: boolean;
   simulatedRole?: "operator" | "territory";
   onChangeTerritory: (id: number | null) => void;
   onChangeOperator: (id: number | null) => void;
   onChangeSimulate: (state: boolean) => void;
   onChangeSimulatedRole: (value: "operator" | "territory" | undefined) => void;
+  // Bascule serveur du périmètre actif (distincte du mode simulate admin).
+  switchScope: (territory_id: number) => Promise<void>;
+  // Signale qu'un formulaire est en cours d'édition (garde-fou avant bascule).
+  setFormEditing: (editing: boolean) => void;
   logout: () => void;
 }
+
+// Libellé du périmètre pour un registry.admin sans scope attribué.
+export const ADMIN_SCOPE_LABEL = "Administration RPC";
 
 export const roles = [
   "anonymous",

--- a/app-partners/src/interfaces/dataInterface.ts
+++ b/app-partners/src/interfaces/dataInterface.ts
@@ -13,7 +13,16 @@ export interface UsersInterface {
     territory_id?: number;
     phone?: string;
     role: string;
+    login_siren?: string | null;
+    scopes?: UserScopeInput[];
   }[];
+}
+
+// Périmètre édité dans le formulaire user (réservé registry.admin côté API).
+export interface UserScopeInput {
+  operator_id?: number;
+  territory_id?: number;
+  is_default?: boolean;
 }
 
 export interface Company {

--- a/app-partners/src/providers/AuthProvider.tsx
+++ b/app-partners/src/providers/AuthProvider.tsx
@@ -1,8 +1,14 @@
 "use client";
-import { getUserSession } from "@/helpers/auth";
+import { activeScopeLabel, getActiveScope, getUserSession, postAuthContext } from "@/helpers/auth";
 import { type AuthContextProps } from "@/interfaces/auth";
+import { fr } from "@codegouvfr/react-dsfr";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 import { usePathname, useRouter } from "next/navigation";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+
+// Clés du miroir client (affichage + ré-assertion après reload).
+const MIRROR_KEY = "rpc.active_territory_id";
+const TOAST_KEY = "rpc.scope_switch_toast";
 
 const AuthContext = createContext<AuthContextProps | undefined>(undefined);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -11,14 +17,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [simulate, setSimulate] = useState(false);
   const [simulatedRole, setSimulatedRole] = useState<"operator" | "territory" | undefined>(undefined);
   const [loading, setLoading] = useState(true);
+  const [switchToast, setSwitchToast] = useState<string>();
+  const formEditingRef = useRef(false);
   const router = useRouter();
   const pathname = usePathname();
 
   const checkAuth = async () => {
     const data = await getUserSession();
     if (data?.role && data?.role !== "anonymous") {
+      // Ré-assertion : si la session serveur est repartie sur le défaut, restaurer le scope choisi.
+      const mirror = Number(sessionStorage.getItem(MIRROR_KEY)) || null;
+      const stillGranted = mirror && data.scopes?.some((s) => s.territory_id === mirror);
+      if (stillGranted && data.territory_id !== mirror) {
+        try {
+          await postAuthContext(mirror);
+          data.territory_id = mirror;
+          data.operator_id = null;
+        } catch {
+          sessionStorage.removeItem(MIRROR_KEY);
+        }
+      }
       setIsAuth(true);
       setUser(data);
+      // Toast en attente après le reload consécutif à une bascule.
+      const pending = sessionStorage.getItem(TOAST_KEY);
+      if (pending) {
+        setSwitchToast(pending);
+        sessionStorage.removeItem(TOAST_KEY);
+      }
     } else {
       setIsAuth(false);
       setUser(data);
@@ -39,6 +65,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     }
   }, [loading, isAuth, pathname, router]);
+
+  // Réconciliation avec le serveur au retour d'onglet (le miroir ne fait jamais autorité).
+  useEffect(() => {
+    const reconcile = () => {
+      if (document.visibilityState !== "visible" || !isAuth) return;
+      void getUserSession().then((data) => {
+        if (data?.role && data.role !== "anonymous") setUser(data);
+      });
+    };
+    document.addEventListener("visibilitychange", reconcile);
+    window.addEventListener("focus", reconcile);
+    return () => {
+      document.removeEventListener("visibilitychange", reconcile);
+      window.removeEventListener("focus", reconcile);
+    };
+  }, [isAuth]);
 
   // clean up user on simulatedRole reset
   useEffect(() => {
@@ -79,9 +121,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const setFormEditing = (editing: boolean) => {
+    formEditingRef.current = editing;
+  };
+
+  // Bascule serveur du périmètre actif puis recharge pour ré-hydrater toutes les données de page.
+  const switchScope = async (territory_id: number) => {
+    if (user?.territory_id === territory_id) return;
+    if (formEditingRef.current && !window.confirm("Un formulaire est en cours d'édition. Changer de périmètre ?")) {
+      return;
+    }
+    const { label } = await postAuthContext(territory_id);
+    sessionStorage.setItem(MIRROR_KEY, String(territory_id));
+    sessionStorage.setItem(TOAST_KEY, `Périmètre actif : ${label}`);
+    window.location.reload();
+  };
+
   const logout = () => {
     setIsAuth(false);
     setUser(undefined);
+    sessionStorage.removeItem(MIRROR_KEY);
   };
 
   return (
@@ -90,15 +149,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isAuth,
         setIsAuth,
         user,
+        scopes: user?.scopes ?? [],
+        activeScope: getActiveScope(user),
         simulate,
         simulatedRole,
         onChangeTerritory,
         onChangeOperator,
         onChangeSimulate,
         onChangeSimulatedRole,
+        switchScope,
+        setFormEditing,
         logout,
       }}
     >
+      {switchToast && (
+        <div aria-live="polite" role="status" className={fr.cx("fr-container")} style={{ position: "fixed", top: "1rem", left: 0, right: 0, zIndex: 1000 }}>
+          <Alert
+            severity="success"
+            title="Périmètre changé"
+            description={switchToast}
+            closable
+            onClose={() => setSwitchToast(undefined)}
+          />
+        </div>
+      )}
       {!loading && children}
     </AuthContext.Provider>
   );
@@ -111,3 +185,5 @@ export const useAuth = () => {
   }
   return context;
 };
+
+export { activeScopeLabel };

--- a/app-partners/src/providers/AuthProvider.tsx
+++ b/app-partners/src/providers/AuthProvider.tsx
@@ -1,8 +1,14 @@
 "use client";
-import { getUserSession } from "@/helpers/auth";
-import { type AuthContextProps } from "@/interfaces/auth";
+import { activeScopeLabel, getActiveScope, getUserSession, postAuthContext } from "@/helpers/auth";
+import { type AuthContextProps, type UserInterface } from "@/interfaces/auth";
+import { fr } from "@codegouvfr/react-dsfr";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 import { usePathname, useRouter } from "next/navigation";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+
+// Clés du miroir client (affichage + ré-assertion après reload).
+const MIRROR_KEY = "rpc.active_territory_id";
+const TOAST_KEY = "rpc.scope_switch_toast";
 
 const AuthContext = createContext<AuthContextProps | undefined>(undefined);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -11,14 +17,37 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [simulate, setSimulate] = useState(false);
   const [simulatedRole, setSimulatedRole] = useState<"operator" | "territory" | undefined>(undefined);
   const [loading, setLoading] = useState(true);
+  const [switchToast, setSwitchToast] = useState<{ severity: "success" | "error"; description: string }>();
+  const formEditingRef = useRef(false);
   const router = useRouter();
   const pathname = usePathname();
+
+  // Ré-assertion : si la session serveur est repartie sur le défaut, restaurer le scope choisi.
+  const assertMirror = async (data: UserInterface) => {
+    const mirror = Number(sessionStorage.getItem(MIRROR_KEY)) || null;
+    const stillGranted = mirror && data.scopes?.some((s) => s.territory_id === mirror);
+    if (!stillGranted || data.territory_id === mirror) return;
+    try {
+      await postAuthContext(mirror);
+      data.territory_id = mirror;
+      data.operator_id = null;
+    } catch {
+      sessionStorage.removeItem(MIRROR_KEY);
+    }
+  };
 
   const checkAuth = async () => {
     const data = await getUserSession();
     if (data?.role && data?.role !== "anonymous") {
+      await assertMirror(data);
       setIsAuth(true);
       setUser(data);
+      // Toast en attente après le reload consécutif à une bascule.
+      const pending = sessionStorage.getItem(TOAST_KEY);
+      if (pending) {
+        setSwitchToast({ severity: "success", description: pending });
+        sessionStorage.removeItem(TOAST_KEY);
+      }
     } else {
       setIsAuth(false);
       setUser(data);
@@ -39,6 +68,31 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     }
   }, [loading, isAuth, pathname, router]);
+
+  // Réconciliation avec le serveur au retour d'onglet (le miroir ne fait jamais autorité).
+  useEffect(() => {
+    const reconcile = () => {
+      if (document.visibilityState !== "visible" || !isAuth) return;
+      getUserSession()
+        .then(async (data) => {
+          if (!data?.role || data.role === "anonymous") return;
+          await assertMirror(data);
+          // Le tuple simulé n'existe qu'en local : le serveur ne doit pas l'écraser.
+          setUser((prev) =>
+            prev && simulate ? { ...data, territory_id: prev.territory_id, operator_id: prev.operator_id } : data,
+          );
+        })
+        .catch(() => {
+          // Reconcile opportuniste : un /auth/me en échec ne doit pas casser la page.
+        });
+    };
+    document.addEventListener("visibilitychange", reconcile);
+    window.addEventListener("focus", reconcile);
+    return () => {
+      document.removeEventListener("visibilitychange", reconcile);
+      window.removeEventListener("focus", reconcile);
+    };
+  }, [isAuth, simulate]);
 
   // clean up user on simulatedRole reset
   useEffect(() => {
@@ -79,9 +133,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const setFormEditing = (editing: boolean) => {
+    formEditingRef.current = editing;
+  };
+
+  // Bascule serveur du périmètre actif puis recharge pour ré-hydrater toutes les données de page.
+  const switchScope = async (territory_id: number) => {
+    if (user?.territory_id === territory_id) return;
+    if (formEditingRef.current && !window.confirm("Un formulaire est en cours d'édition. Changer de périmètre ?")) {
+      return;
+    }
+    try {
+      const { label } = await postAuthContext(territory_id);
+      sessionStorage.setItem(MIRROR_KEY, String(territory_id));
+      if (label) sessionStorage.setItem(TOAST_KEY, `Périmètre actif : ${label}`);
+      window.location.reload();
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "Bascule de périmètre impossible";
+      setSwitchToast({ severity: "error", description });
+      // La session serveur fait foi après un refus : on réaligne l'affichage.
+      await checkAuth().catch(() => undefined);
+    }
+  };
+
   const logout = () => {
     setIsAuth(false);
     setUser(undefined);
+    sessionStorage.removeItem(MIRROR_KEY);
+    sessionStorage.removeItem(TOAST_KEY);
   };
 
   return (
@@ -90,15 +169,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isAuth,
         setIsAuth,
         user,
+        scopes: user?.scopes ?? [],
+        activeScope: getActiveScope(user),
         simulate,
         simulatedRole,
         onChangeTerritory,
         onChangeOperator,
         onChangeSimulate,
         onChangeSimulatedRole,
+        switchScope,
+        setFormEditing,
         logout,
       }}
     >
+      {switchToast && (
+        <div aria-live="polite" role="status" className={fr.cx("fr-container")} style={{ position: "fixed", top: "1rem", left: 0, right: 0, zIndex: 1000 }}>
+          <Alert
+            severity={switchToast.severity}
+            title={switchToast.severity === "error" ? "Bascule impossible" : "Périmètre changé"}
+            description={switchToast.description}
+            closable
+            onClose={() => setSwitchToast(undefined)}
+          />
+        </div>
+      )}
       {!loading && children}
     </AuthContext.Provider>
   );
@@ -111,3 +205,5 @@ export const useAuth = () => {
   }
   return context;
 };
+
+export { activeScopeLabel };


### PR DESCRIPTION
## Contexte

Tranche **T5** (front) du chantier multi-SIRET/multi-périmètre (GEN-686). Stackée sur T3 (#3324). Consomme les contrats API de T2 (#3322) / T3 (#3324) / T4 (#3323).

## Contenu — dashboard partenaire (`app-partners`)

- **`ScopeSwitcher`** (header) : combobox recherchable (`@mui/material/Autocomplete`, pattern `SelectGeo`) si l'utilisateur a >1 territoire, **badge statique** sinon ; coche l'actif ; `POST /auth/context` → toast `Alert` `aria-live` (RGAA) → reload (ré-hydrate les pages qui lisent le périmètre). Ne bascule que les scopes **territoire**.
- **`ProfilButton`** : affiche le **libellé** du périmètre (corrige l'affichage de l'ID brut).
- **`AuthProvider`** : `scopes[]`, scope actif, `switchScope`, miroir `sessionStorage` + réconciliation `focus`/`visibilitychange` (survit au reload, ré-assère si la session est repartie sur le défaut), garde-fou `confirm` si un formulaire est en édition.
- **`ActiveScopeBadge`** : rappel « Périmètre actif : {label} » en tête des écrans **export** et **campagnes** + dans l'alerte de succès d'export.
- **Formulaire utilisateur** : `fieldset` Identité / Connexion / Périmètres. `login_siren` étiqueté « SIREN de connexion (ProConnect) », hint « 9 chiffres — distinct du SIRET du territoire », validé `^\d{9}$`, pré-rempli. **`UserScopesEditor`** : `Table` + radio défaut + `Autocomplete` d'ajout ; user opérateur = un seul `Select` sans ajout ; sections **masquées** pour un `territory.admin` (gating `registry.admin`).
- États limites : 0 scope (« Administration RPC »), retrait du défaut (promotion auto), dernier scope non retirable.

## Validation

- `tsc --noEmit` propre sur les fichiers ajoutés (2 erreurs pré-existantes non liées dans `not-found.tsx`, résolues par Next au build).
- `npm run lint` (eslint) : exit 0.
- Pas de runner de test front dans le repo.

## Adaptations (documentées)

- Pas de React Query dans ce dashboard → invalidation via `reload` après bascule (toast persisté en `sessionStorage`).
- Pas de modale de confirmation d'export → rappel du périmètre en tête d'écran + dans l'alerte de succès.
- Contrat API à valider end-to-end une fois T2/T4 mergés.
