### PR TITLE
docs(api): corrige le lien des statistiques publiques dans la spec v3.4

### DIFF
--- a/api/specs/api-v3.4.yaml
+++ b/api/specs/api-v3.4.yaml
@@ -38,7 +38,7 @@ info:
     - [Le site vitrine](https://covoiturage.beta.gouv.fr/) présente le produit ;
     - [La documentation générale](https://doc.covoiturage.beta.gouv.fr/) ;
     - [Espace partenaire](https://partenaire.covoiturage.beta.gouv.fr/) permet aux opérateurs et aux territoires de gérer les campagnes ;
-    - [Les statistiques](https://stats.covoiturage.beta.gouv.fr/public/dashboard/2084d346-8e3b-495e-9b10-b4870a35632a) des chiffres clés de la Startup d'État ;
+    - [Les statistiques](https://observatoire.covoiturage.gouv.fr/startup-etat/stats/) des chiffres clés de la Startup d'État ;
     - [Le statut des applications](https://status.covoiturage.beta.gouv.fr/) pour suivre les incidents et l'accessibilité des services ;
     - [Le générateur d'attestations sur l'honneur](https://attestation.covoiturage.beta.gouv.fr/) permet aux personnes qui covoiturent de produire facilement un document pour leur employeur dans le but de profiter du Forfait Mobilités Durables.
 


### PR DESCRIPTION
## Résumé

Le dashboard Metabase public référencé dans la spec API v3.4 passe intégralement derrière oauth2-proxy (ADR infra 0002) : le lien renvoyait donc un 403 pour tout visiteur hors équipe. Les statistiques publiques citoyennes sont désormais servies par l'observatoire.

## Changement

- `api/specs/api-v3.4.yaml` : le lien « Les statistiques » pointe maintenant vers `https://observatoire.covoiturage.gouv.fr/startup-etat/stats/` (200 vérifié) au lieu du dashboard Metabase public.

Seul ce fichier référençait ce dashboard (`rg 'public/dashboard'` ne remonte que lui). `README.md` mentionne Metabase avec la note « (interne) », correcte après la bascule, laissée en l'état.

## Checks

- **CGU** : PASS — changement purement documentaire, aucune règle applicable.
- **Sécurité** : PASS — domaine de destination déjà de confiance ailleurs dans le repo, aucune fuite ni risque introduit.