### PR TITLE
fix(datalake): clé de jointure (year, arr, l_arr) sur old_perimeters

### DIFF
--- a/datalake/models/trusted/perimeters.sql
+++ b/datalake/models/trusted/perimeters.sql
@@ -41,11 +41,13 @@ WITH old_perimeters AS (
     ST_SETSRID(c.geom, 4326)  AS centroid,
     MAKE_DATE(a.year, 1, 1)   AS valid_from,
     MAKE_DATE(a.year, 12, 31) AS valid_until
+  -- (year, arr) non unique sur l'étranger 2021-2023 (XXXXX = 7 territoires),
+  -- la clé est (year, arr, l_arr)
   FROM {{ source('raw', 'old_perimeters_simple') }} AS a
   LEFT JOIN {{ source('raw', 'old_perimeters_full') }} AS b
-    ON a.year = b.year AND a.arr = b.arr
+    ON a.year = b.year AND a.arr = b.arr AND a.l_arr = b.l_arr
   LEFT JOIN {{ source('raw', 'old_perimeters_centroid') }} AS c
-    ON a.year = c.year AND a.arr = c.arr
+    ON a.year = c.year AND a.arr = c.arr AND a.l_arr = c.l_arr
 ),
 
 new_com AS (

--- a/datalake/tests/trusted/perimeters_unique_key.sql
+++ b/datalake/tests/trusted/perimeters_unique_key.sql
@@ -1,0 +1,12 @@
+{{ config(severity='error', tags=['trusted', 'geo', 'perimeters']) }}
+
+-- Clé métier = (year, arr, l_arr) : (year, arr) n'est pas unique sur l'étranger
+-- 2021-2023. Un doublon = jointure cubée, qui explose au prochain reseed.
+SELECT
+  year,
+  arr,
+  l_arr,
+  COUNT(*) AS n
+FROM {{ ref('perimeters') }}
+GROUP BY year, arr, l_arr
+HAVING COUNT(*) > 1


### PR DESCRIPTION
## Résumé

`just pipeline-trusted-geo` plantait sur `zone_trusted.perimeters` avec `No space left on device` (fichiers temp Postgres).

Cause : dans `old_perimeters_{simple,full,centroid}`, `(year, arr)` n'est pas unique sur l'étranger 2021‑2023 (`XXXXX` = 7 territoires, `99425` = 6…). La triple jointure cube les lignes. `archive-old-perimeters` ré‑exporte le gpkg depuis `perimeters`, donc chaque cycle archive/reseed élève le facteur au cube : 7 → 343 → 117 649 lignes par clé métier.

## Changements

- `models/trusted/perimeters.sql` : `l_arr` ajouté à la clé des deux jointures `old_perimeters`.
- `tests/trusted/perimeters_unique_key.sql` : test d'unicité `(year, arr, l_arr)` sur `perimeters`.

## État de la production — déjà appliqué

Le reseed et la reconstruction ont été faits le 2026‑09‑07 :

1. Les 3 tables `old_perimeters_*` ont été rechargées depuis `old_perimeters.20260703T224007Z` (le gpkg d'août était inexploitable, géométries croisées avec les libellés). Résultat : 210 931 lignes, `(year, arr, l_arr)` unique, années 2019‑2024.
2. `just pipeline-trusted-geo` : vert en 2 min 05 (contre 11 min 44 avant échec). `perimeters` = 246 065 lignes, `perimeters_agg` = 260 506.
3. `perimeters_unique_key` : PASS.

Contrôles : 7 lignes `XXXXX` par année au lieu de 1 095, aucune géométrie nulle introduite, les 7 années présentes.

Impact aval mesuré comme nul : la macro `carpools_perim_join` joint sans déduplication, mais un seul trajet sur 2021‑2023 porte un des codes concernés. Aucun réagrégat nécessaire.

## Reste à faire

Régénérer l'archive `old_perimeters` depuis le `perimeters` sain, puis reprendre la bascule 2026 sur la branche `dlk_geo_2026`.

## Release

PR data-only (`datalake`) : pas de release ni de déploiement applicatif.