### PR TITLE
chore(datalake): passe le pipeline géo en dbt build pour exécuter le test d'unicité

### DIFF
--- a/datalake/README.md
+++ b/datalake/README.md
@@ -264,6 +264,8 @@ just pipeline-trusted-geo
 
 Construit la hiérarchie géographique dans `zone_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools.
 
+La clé métier d'un périmètre est **`(year, arr, l_arr)`** : `(year, arr)` seul n'est pas unique sur l'étranger, où un même code couvre plusieurs territoires (`XXXXX` = France, Nouvelle-Calédonie, Polynésie…). Le pipeline passe par `dbt build`, donc le test d'unicité s'intercale entre `perimeters` et ses modèles avals, et c'est un garde-fou, pas une formalité : `archive-old-perimeters` réinjecte `perimeters` dans la zone raw, donc une duplication non détectée est élevée au cube à chaque cycle archive/reseed jusqu'à saturer le disque temporaire de Postgres.
+
 ### Étape 2 bis — Stats des tables distantes (FDW)
 
 ```bash

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -120,8 +120,11 @@ pipeline-raw *args:
   just seed raw/seed_raw.json zone_raw --folder seeds {{ if args =~ "--full-refresh" { "--overwrite" } else { "" } }}
 
 # Pipeline 2: trusted geo (yearly)
+# `build` et non `run` : le test d'unicite suit les modeles. Une duplication de
+# perimeters serait recopiee dans la raw par `archive-old-perimeters`, puis elevee
+# au cube au reseed suivant.
 pipeline-trusted-geo *args:
-  just dbt run --select "tag:trusted,tag:geo" {{args}}
+  just dbt build --select "tag:trusted,tag:geo" {{args}}
 
 # Pipeline 3 : daily update (agrégés taggés daily + zone exposée + invalidation du cache).
 # Un seul `dbt run` sur l'union => dbt ordonne le DAG (agrégés frais avant l'exposé).


### PR DESCRIPTION
## Résumé

Suite de #3343. Le test d'unicité `perimeters_unique_key` était en place, mais aucun pipeline ne lançait `dbt test` : il ne se serait jamais exécuté.

`pipeline-trusted-geo` passe donc par `dbt build`. Le test s'intercale entre `perimeters` et ses modèles avals, et bloque la suite en cas de duplication. `build` plutôt que `run` puis `test` pour que les arguments de la recette s'appliquent aux deux.

## Pourquoi c'est un garde-fou et pas une formalité

`archive-old-perimeters` réinjecte `perimeters` dans la zone raw. Une duplication non détectée y est recopiée, puis élevée au cube au reseed suivant, et ainsi de suite à chaque cycle : 7 → 343 → 117 649 lignes par clé métier. C'est la mécanique qui a mené à `No space left on device`.

Le README documente la clé `(year, arr, l_arr)` et ce cycle.

## Vérification

`just pipeline-trusted-geo` complet sur la production : `perimeters` = 246 065, `perimeters_unique_key` PASS, `perimeters_agg` = 260 506, `Completed successfully`.

## Attention pour la bascule 2026

La branche `dlk_geo_2026` porte encore la jointure sur `(year, arr)`. Même sur la raw saine, cette clé compte 87 doublons, donc la branche recrée le bug telle quelle. Elle doit être rebasée sur `main` avant d'être reprise.

## Release

PR data-only (`datalake`) : pas de release ni de déploiement applicatif.