### PR TITLE
fix(datalake): recrée les vues exposées après le pipeline geo

### DIFF
--- a/datalake/README.md
+++ b/datalake/README.md
@@ -262,7 +262,7 @@ Charge les données IGN 2025 (GPKG), CEREMA AOMs, mouvements INSEE, campagnes et
 just pipeline-trusted-geo
 ```
 
-Construit la hiérarchie géographique dans `zone_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools.
+Construit la hiérarchie géographique dans `zone_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools. Les tables `perimeters`/`perimeters_agg` sont reconstruites par `DROP … CASCADE`, ce qui supprime les vues aval de `zone_exposed` : la recette enchaîne donc systématiquement un `dbt run` des vues exposées.
 
 ### Étape 2 bis — Stats des tables distantes (FDW)
 

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -122,6 +122,9 @@ pipeline-raw *args:
 # Pipeline 2: trusted geo (yearly)
 pipeline-trusted-geo *args:
   just dbt run --select "tag:trusted,tag:geo" {{args}}
+  # perimeters/perimeters_agg sont des tables : dbt les reconstruit par DROP … CASCADE,
+  # ce qui supprime les vues aval de zone_exposed. On les recrée.
+  just dbt run --select "models/exposed,config.materialized:view" {{args}}
 
 # Pipeline 3 : daily update (agrégés taggés daily + zone exposée + invalidation du cache).
 # Un seul `dbt run` sur l'union => dbt ordonne le DAG (agrégés frais avant l'exposé).


### PR DESCRIPTION
## Résumé

`pipeline-trusted-geo` reconstruit `perimeters` et `perimeters_agg`, matérialisées en tables. dbt-postgres les recrée par `DROP … CASCADE`, ce qui supprimait au passage les vues aval de `zone_exposed` (`campaigns`, `observatory_perimeters`, `export_partners`, `export_opendata`) : publication open-data en échec et API observatoire dégradée jusqu'au `pipeline-daily` suivant.

La recette enchaîne désormais un `dbt run` des vues exposées après le run géo, avec les mêmes arguments pour garder la cible dbt choisie. README mis à jour.

## Release

Data-only (`datalake/`) : pas de version, pas de déploiement applicatif.
