### PR TITLE
fix(datalake): carpools unique_key sur _id seul (doublons de statut)

### DIFF
--- a/datalake/models/trusted/carpools.sql
+++ b/datalake/models/trusted/carpools.sql
@@ -2,7 +2,7 @@
 {{ config(
     materialized='incremental',
     incremental_strategy='delete+insert',
-    unique_key=['_id', 'fraud_status', 'anomaly_status', 'acquisition_status'],
+    unique_key=['_id'],
     indexes = [
       { 'columns':['_id'] },
       { 'columns':['start_datetime_tz'] },

--- a/datalake/models/trusted/yml/_carpools.yml
+++ b/datalake/models/trusted/yml/_carpools.yml
@@ -4,6 +4,9 @@ models:
     columns:
       - name: _id
         data_type: integer
+        data_tests:
+          - unique
+          - not_null
       - name: uuid
         data_type: character varying
       - name: legacy_id

--- a/datalake/tests/trusted/carpools/carpools_row_count.sql
+++ b/datalake/tests/trusted/carpools/carpools_row_count.sql
@@ -1,4 +1,3 @@
--- COUNT(DISTINCT _id) côté modèle car unique_key inclut les champs de statut.
 {{ config(severity='warn', tags=['trusted', 'carpools']) }}
 
 SELECT 1 AS failure
@@ -9,7 +8,7 @@ WHERE (
     >= {{ window_start(ref('carpools'), 'start_datetime', lookback_nb=3) }}
     AND start_datetime <= CURRENT_TIMESTAMP
 ) != (
-  SELECT COUNT(DISTINCT _id) FROM {{ ref('carpools') }}
+  SELECT COUNT(*) FROM {{ ref('carpools') }}
   WHERE
     start_datetime
     >= {{ window_start(ref('carpools'), 'start_datetime', lookback_nb=3) }}


### PR DESCRIPTION
## Résumé

`zone_trusted.carpools` accumule des lignes dupliquées (même `_id`, statuts différents) : la clé du `delete+insert` incluait `fraud_status`, `anomaly_status` et `acquisition_status`, donc l'ancienne ligne « pending » n'était jamais supprimée quand le statut passait à « passed ». Environ 2,5 % de la table, concentrés sur la fenêtre de lookback. Les agrégats `fraud_*` en héritent (`carpools`, `carpools_invalid`).

- `unique_key=['_id']` sur `trusted/carpools.sql`
- test `carpools_row_count` : `COUNT(*)` au lieu de `COUNT(DISTINCT _id)` (le contournement n'a plus lieu d'être)
- tests `unique` + `not_null` sur `carpools._id` (`_carpools.yml`)

## Déploiement

`dbt run --full-refresh --select carpools+` (la table puis les agrégats aval), sinon les doublons existants restent.

## Release

Data-only (`datalake`) : pas de release.
