### PR TITLE
fix(datalake): compte les trajets non valides et non la seule fraude

### DIFF
--- a/datalake/models/app_metabase/mb_carpools_per_operator.sql
+++ b/datalake/models/app_metabase/mb_carpools_per_operator.sql
@@ -7,7 +7,7 @@ SELECT -- noqa: ST06
   to_char(incremental_date, 'YYYY-MM') AS date,
   operator_id,
   operator_name                        AS name,
-  sum(carpools)                        AS trips,
+  sum(carpools)                        AS carpools,
   sum(carpools_valid)                  AS ok,
   sum(carpools_invalid)                AS error
 FROM {{ ref('fraud_month_country_from') }}

--- a/datalake/models/app_metabase/mb_operator_first_trip.sql
+++ b/datalake/models/app_metabase/mb_operator_first_trip.sql
@@ -8,5 +8,5 @@ select
   operator_name as name,
   first_date    as min,
   last_date     as max,
-  carpools      as trips
+  carpools
 from {{ ref('operators') }}

--- a/datalake/models/app_metabase/mb_public_stats.sql
+++ b/datalake/models/app_metabase/mb_public_stats.sql
@@ -3,8 +3,12 @@
   tags=['app_metabase', 'public_stats']
 ) }}
 
-with fraudulous_carpools as (
-  select SUM(carpools_fraud) as fraudulous_trips_count
+with invalid_carpools as (
+  select
+    SUM(carpools_invalid)         as invalid_carpools_count,
+    SUM(carpools_fraud)           as fraud_carpools_count,
+    SUM(carpools_anomaly)         as anomaly_carpools_count,
+    SUM(carpools_terms_violation) as terms_violation_carpools_count
   from {{ ref('fraud_year_country_from') }}
 ),
 
@@ -15,12 +19,12 @@ valid_carpools as (
     COUNT(distinct operator_id)
       as operators_count,
     SUM(carpools)
-      as validated_trips_count
+      as validated_carpools_count
   from {{ ref('operators') }}
 ),
 
 subsidized_carpools as (
-  select COUNT(distinct carpool_v2_id) as subsidized_trips_count
+  select COUNT(distinct carpool_v2_id) as subsidized_carpools_count
   from {{ ref('incentives') }}
   where amount > 0
 )
@@ -28,10 +32,13 @@ subsidized_carpools as (
 select
   valid_carpools.average_carpoolers_by_car,
   valid_carpools.operators_count,
-  valid_carpools.validated_trips_count,
-  fraudulous_carpools.fraudulous_trips_count,
-  subsidized_carpools.subsidized_trips_count
+  valid_carpools.validated_carpools_count,
+  invalid_carpools.invalid_carpools_count,
+  invalid_carpools.fraud_carpools_count,
+  invalid_carpools.anomaly_carpools_count,
+  invalid_carpools.terms_violation_carpools_count,
+  subsidized_carpools.subsidized_carpools_count
 
-from fraudulous_carpools
+from invalid_carpools
 cross join valid_carpools
 cross join subsidized_carpools


### PR DESCRIPTION
## Résumé

Suite de la revue de #3337. Trois corrections sur les vues `app_metabase`.

**Trajets rejetés comptés trop bas.** `mb_public_stats` ne retenait que la fraude là où le legacy comptait tous les trajets non valides : 15 576 contre 1 363 491 sur l'historique complet. La vue expose désormais `invalid_carpools_count`, avec le détail par statut (fraude, anomalie, CGU).

**Nommage en « carpools ».** Le legacy disait « trips » mais comptait des carpools. Les alias de volume repassent en `carpools` pour lever l'ambiguïté. Les colonnes sur lesquelles les cartes filtrent (`date`, `name`, `min`, `max`, `ok`, `error`) sont inchangées.

**Périmètre géographique inchangé.** Toutes les vues restent sur le périmètre complet, France et étranger confondus, par parité avec les chiffres publiés. Exposer le code pays a été écarté : cela ferait passer les vues à un grain mois × pays et la carte North Star, publique et embarquée, afficherait plusieurs lignes par mois. Si le besoin de filtrer se confirme, il vaudra mieux une vue dédiée qu'un changement de grain sur les vues existantes.

## Repointage des cartes

Six cartes sélectionnent `validated_trips_count` / `fraudulous_trips_count` nommément : leur requête est à éditer, le changement de table lue ne suffit pas.

## Déploiement

Les volumes de non-valides sont encore gonflés par les doublons corrigés en #3346 : `dbt run --full-refresh --select carpools+` avant toute comparaison de chiffres, et full-refresh de `fraud_month_country_from` pour `avoided_incentives`.

## Release

Data-only (`datalake`) : pas de release.
