### PR TITLE
feat(auth): supprime les colonnes de périmètre legacy sur auth.users (GEN-686) [T6/6]

### DIFF
--- a/api/src/db/migrations/20260907120000-drop-user-scope-legacy-columns.sql
+++ b/api/src/db/migrations/20260907120000-drop-user-scope-legacy-columns.sql
@@ -1,0 +1,4 @@
+-- Contract GEN-686 : auth.user_scopes est la seule source de vérité des périmètres.
+ALTER TABLE auth.users
+  DROP COLUMN operator_id,
+  DROP COLUMN territory_id;

--- a/api/src/db/migrations/20260907120000-drop-user-scope-legacy-columns.sql
+++ b/api/src/db/migrations/20260907120000-drop-user-scope-legacy-columns.sql
@@ -1,3 +1,44 @@
+-- Rattrapage idempotent avant le DROP : reprend le backfill de 20260718100000, opérateur prioritaire.
+INSERT INTO auth.user_scopes (user_id, operator_id, is_default)
+SELECT u._id, u.operator_id, true FROM auth.users u
+WHERE u.operator_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+
+INSERT INTO auth.user_scopes (user_id, territory_id, is_default)
+SELECT u._id, u.territory_id, true FROM auth.users u
+WHERE u.territory_id IS NOT NULL AND u.operator_id IS NULL
+  AND NOT EXISTS (SELECT 1 FROM auth.user_scopes s WHERE s.user_id = u._id);
+
+-- Garde bloquante : aucun périmètre legacy ne doit disparaître avec les colonnes.
+DO $$
+DECLARE
+  orphans int;
+BEGIN
+  SELECT count(*) INTO orphans
+  FROM auth.users u
+  WHERE (
+      u.operator_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM auth.user_scopes s
+        WHERE s.user_id = u._id AND s.operator_id = u.operator_id
+      )
+    )
+    OR (
+      u.operator_id IS NULL AND u.territory_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM auth.user_scopes s
+        WHERE s.user_id = u._id AND s.territory_id = u.territory_id
+      )
+    );
+
+  IF orphans > 0 THEN
+    RAISE EXCEPTION
+      'Migration interrompue : % compte(s) portent un périmètre dans auth.users (operator_id/territory_id) sans ligne équivalente dans auth.user_scopes. Supprimer ces colonnes perdrait leur périmètre. Réconcilier auth.user_scopes pour ces comptes avant de rejouer la migration.',
+      orphans;
+  END IF;
+END;
+$$;
+
 -- Contract GEN-686 : auth.user_scopes est la seule source de vérité des périmètres.
 ALTER TABLE auth.users
   DROP COLUMN operator_id,

--- a/api/src/pdc/providers/migration/DenoMigrator.integration.spec.ts
+++ b/api/src/pdc/providers/migration/DenoMigrator.integration.spec.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
 import { env_or_fail } from "../../../lib/env/index.ts";
 import sql from "../../../lib/pg/sql.ts";
 import { DenoMigrator } from "./DenoMigrator.ts";
+import { adminIleDeFrance, adminMaxiCovoit } from "./seeds/users.ts";
 
 describe("seed", () => {
   const mig = new DenoMigrator(env_or_fail("APP_POSTGRES_URL"));
@@ -21,5 +22,27 @@ describe("seed", () => {
   it("should seed territories", async () => {
     const rows = await mig.testConn.query<{ count: number }>(sql`SELECT count(*) FROM geo.perimeters`);
     assertEquals(rows[0].count, 17);
+  });
+
+  it("should restore user scopes when seeding twice", async () => {
+    await mig.testConn.query(sql`DELETE FROM auth.user_scopes`);
+
+    await mig.seedUser(adminMaxiCovoit);
+    await mig.seedUser(adminIleDeFrance);
+
+    const rows = await mig.testConn.query<{ email: string; operator_id: number | null; territory_id: number | null }>(
+      sql`
+        SELECT u.email, s.operator_id, s.territory_id
+        FROM auth.user_scopes s
+        JOIN auth.users u ON u._id = s.user_id
+        WHERE u.email IN (${adminMaxiCovoit.email}, ${adminIleDeFrance.email})
+        ORDER BY u.email
+      `,
+    );
+
+    assertEquals(rows, [
+      { email: adminMaxiCovoit.email, operator_id: 1, territory_id: null },
+      { email: adminIleDeFrance.email, operator_id: null, territory_id: 1 },
+    ]);
   });
 });

--- a/api/src/pdc/providers/migration/DenoMigrator.ts
+++ b/api/src/pdc/providers/migration/DenoMigrator.ts
@@ -321,20 +321,33 @@ export class DenoMigrator {
   }
 
   async seedUser(user: User) {
-    await this.testConn.query(sql`
+    const rows = await this.testConn.query<{ _id: number }>(sql`
       INSERT INTO auth.users
-        (email, firstname, lastname, password, status, role, territory_id, operator_id)
+        (email, firstname, lastname, password, status, role)
       VALUES (
         ${user.email}::varchar,
         ${user.firstname}::varchar,
         ${user.lastname}::varchar,
         ${user.password}::varchar,
         ${user.status}::auth.user_status_enum,
-        ${user.role}::varchar,
-        ${user.territory?._id},
-        ${user.operator?._id}
+        ${user.role}::varchar
       )
-      ON CONFLICT DO NOTHING 
+      ON CONFLICT DO NOTHING
+      RETURNING _id
+    `);
+
+    const userId = rows[0]?._id;
+    const scope = user.operator?._id
+      ? { column: "operator_id", value: user.operator._id }
+      : user.territory?._id
+      ? { column: "territory_id", value: user.territory._id }
+      : null;
+    if (!userId || !scope) return;
+
+    await this.testConn.query(sql`
+      INSERT INTO auth.user_scopes (user_id, ${raw(scope.column)}, is_default)
+      VALUES (${userId}::int, ${scope.value}::int, true)
+      ON CONFLICT DO NOTHING
     `);
   }
 

--- a/api/src/pdc/providers/migration/DenoMigrator.ts
+++ b/api/src/pdc/providers/migration/DenoMigrator.ts
@@ -321,6 +321,7 @@ export class DenoMigrator {
   }
 
   async seedUser(user: User) {
+    // DO UPDATE no-op : RETURNING doit renvoyer l'id même quand l'utilisateur existe déjà (re-seed).
     const rows = await this.testConn.query<{ _id: number }>(sql`
       INSERT INTO auth.users
         (email, firstname, lastname, password, status, role)
@@ -332,21 +333,22 @@ export class DenoMigrator {
         ${user.status}::auth.user_status_enum,
         ${user.role}::varchar
       )
-      ON CONFLICT DO NOTHING
+      ON CONFLICT (email) DO UPDATE SET email = excluded.email
       RETURNING _id
     `);
 
+    const operatorId = user.operator?._id ?? null;
+    const territoryId = user.territory?._id ?? null;
+    if (operatorId === null && territoryId === null) return;
+
     const userId = rows[0]?._id;
-    const scope = user.operator?._id
-      ? { column: "operator_id", value: user.operator._id }
-      : user.territory?._id
-      ? { column: "territory_id", value: user.territory._id }
-      : null;
-    if (!userId || !scope) return;
+    if (!userId) {
+      throw new Error(`[migrator] identifiant introuvable pour ${user.email} : périmètre non seedé`);
+    }
 
     await this.testConn.query(sql`
-      INSERT INTO auth.user_scopes (user_id, ${raw(scope.column)}, is_default)
-      VALUES (${userId}::int, ${scope.value}::int, true)
+      INSERT INTO auth.user_scopes (user_id, operator_id, territory_id, is_default)
+      VALUES (${userId}::int, ${operatorId}::int, ${territoryId}::int, true)
       ON CONFLICT DO NOTHING
     `);
   }

--- a/api/src/pdc/providers/migration/LegacyMigrator.integration.spec.ts
+++ b/api/src/pdc/providers/migration/LegacyMigrator.integration.spec.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "dep:assert";
 import { afterAll, beforeAll, describe, it } from "dep:testing-bdd";
 import { env_or_fail } from "@/lib/env/index.ts";
 import { LegacyMigrator } from "./LegacyMigrator.ts";
+import { adminIleDeFrance, adminMaxiCovoit } from "./seeds/users.ts";
 
 describe("seed", () => {
   const mig = new LegacyMigrator(env_or_fail("APP_POSTGRES_URL"));
@@ -22,5 +23,28 @@ describe("seed", () => {
       text: "SELECT count(*) FROM geo.perimeters",
     });
     assertEquals(result.rows[0].count, "17");
+  });
+
+  it("should restore user scopes when seeding twice", async () => {
+    await mig.testConn.getClient().query({ text: "DELETE FROM auth.user_scopes" });
+
+    await mig.seedUser(adminMaxiCovoit);
+    await mig.seedUser(adminIleDeFrance);
+
+    const result = await mig.testConn.getClient().query({
+      text: `
+        SELECT u.email, s.operator_id, s.territory_id
+        FROM auth.user_scopes s
+        JOIN auth.users u ON u._id = s.user_id
+        WHERE u.email IN ($1, $2)
+        ORDER BY u.email
+      `,
+      values: [adminMaxiCovoit.email, adminIleDeFrance.email],
+    });
+
+    assertEquals(result.rows, [
+      { email: adminMaxiCovoit.email, operator_id: 1, territory_id: null },
+      { email: adminIleDeFrance.email, operator_id: null, territory_id: 1 },
+    ]);
   });
 });

--- a/api/src/pdc/providers/migration/LegacyMigrator.ts
+++ b/api/src/pdc/providers/migration/LegacyMigrator.ts
@@ -421,6 +421,7 @@ export class LegacyMigrator {
   }
 
   async seedUser(user: User) {
+    // DO UPDATE no-op : RETURNING doit renvoyer l'id même quand l'utilisateur existe déjà (re-seed).
     const inserted = await this.testConn.getClient().query({
       text: `
         INSERT INTO auth.users
@@ -433,7 +434,7 @@ export class LegacyMigrator {
           $5::auth.user_status_enum,
           $6::varchar
         )
-        ON CONFLICT DO NOTHING
+        ON CONFLICT (email) DO UPDATE SET email = excluded.email
         RETURNING _id
       `,
       values: [
@@ -446,17 +447,22 @@ export class LegacyMigrator {
       ],
     });
 
+    const operatorId = user.operator?._id ?? null;
+    const territoryId = user.territory?._id ?? null;
+    if (operatorId === null && territoryId === null) return;
+
     const userId = inserted.rows[0]?._id;
-    const scopeColumn = user.operator?._id ? "operator_id" : user.territory?._id ? "territory_id" : null;
-    if (!userId || !scopeColumn) return;
+    if (!userId) {
+      throw new Error(`[migrator] identifiant introuvable pour ${user.email} : périmètre non seedé`);
+    }
 
     await this.testConn.getClient().query({
       text: `
-        INSERT INTO auth.user_scopes (user_id, ${scopeColumn}, is_default)
-        VALUES ($1::int, $2::int, true)
+        INSERT INTO auth.user_scopes (user_id, operator_id, territory_id, is_default)
+        VALUES ($1::int, $2::int, $3::int, true)
         ON CONFLICT DO NOTHING
       `,
-      values: [userId, user.operator?._id ?? user.territory?._id],
+      values: [userId, operatorId, territoryId],
     });
   }
 

--- a/api/src/pdc/providers/migration/LegacyMigrator.ts
+++ b/api/src/pdc/providers/migration/LegacyMigrator.ts
@@ -421,21 +421,20 @@ export class LegacyMigrator {
   }
 
   async seedUser(user: User) {
-    await this.testConn.getClient().query({
+    const inserted = await this.testConn.getClient().query({
       text: `
         INSERT INTO auth.users
-          (email, firstname, lastname, password, status, role, territory_id, operator_id)
+          (email, firstname, lastname, password, status, role)
         VALUES (
           $1::varchar,
           $2::varchar,
           $3::varchar,
           $4::varchar,
           $5::auth.user_status_enum,
-          $6::varchar,
-          $7::int,
-          $8::int
+          $6::varchar
         )
-        ON CONFLICT DO NOTHING 
+        ON CONFLICT DO NOTHING
+        RETURNING _id
       `,
       values: [
         user.email,
@@ -444,9 +443,20 @@ export class LegacyMigrator {
         user.password, // TODO: use cryptoprovider tcrypt password
         user.status,
         user.role,
-        user.territory?._id,
-        user.operator?._id,
       ],
+    });
+
+    const userId = inserted.rows[0]?._id;
+    const scopeColumn = user.operator?._id ? "operator_id" : user.territory?._id ? "territory_id" : null;
+    if (!userId || !scopeColumn) return;
+
+    await this.testConn.getClient().query({
+      text: `
+        INSERT INTO auth.user_scopes (user_id, ${scopeColumn}, is_default)
+        VALUES ($1::int, $2::int, true)
+        ON CONFLICT DO NOTHING
+      `,
+      values: [userId, user.operator?._id ?? user.territory?._id],
     });
   }
 

--- a/api/src/pdc/services/auth/providers/UserRepository.integration.spec.ts
+++ b/api/src/pdc/services/auth/providers/UserRepository.integration.spec.ts
@@ -75,6 +75,19 @@ describe("UserRepository.authenticateByEmail", () => {
     assertEquals(user?.scopes.length, 2);
   });
 
+  // 9 registry.admin en production n'ont aucun périmètre : le login doit rester ouvert.
+  it("authenticates a user without any scope", async () => {
+    const { email } = await createUser(null);
+
+    const user = await repository.authenticateByEmail(email);
+
+    assertEquals(user?.territory_id, null);
+    assertEquals(user?.operator_id, null);
+    assertEquals(user?.siret, null);
+    assertEquals(user?.organisation, null);
+    assertEquals(user?.scopes, []);
+  });
+
   it("returns null for an unknown email", async () => {
     assertEquals(await repository.authenticateByEmail("does-not-exist@example.com"), null);
   });

--- a/api/src/pdc/services/dashboard/actions/users/DeleteUserAction.ts
+++ b/api/src/pdc/services/dashboard/actions/users/DeleteUserAction.ts
@@ -7,6 +7,7 @@ import { UsersRepositoryInterfaceResolver } from "@/pdc/services/dashboard/inter
 export type ResultInterface = {
   success: boolean;
   message: string;
+  outcome: "user_deleted" | "scope_released";
 };
 
 @handler({
@@ -36,8 +37,10 @@ export class DeleteUserAction extends AbstractAction {
 
   public override async handle(params: DeleteUser): Promise<ResultInterface> {
     const result = await this.repository.deleteUser(params);
-    // ON DELETE CASCADE nettoie user_scopes ; on purge aussi les sessions Redis.
-    await this.sessionRepository.destroyByUser(params.id);
+    // Retrait de périmètre : le compte survit, ses sessions restent valides.
+    if (result.outcome === "user_deleted") {
+      await this.sessionRepository.destroyByUser(params.id);
+    }
     return result;
   }
 }

--- a/api/src/pdc/services/dashboard/actions/users/UsersAction.ts
+++ b/api/src/pdc/services/dashboard/actions/users/UsersAction.ts
@@ -13,6 +13,8 @@ export type UserResult = {
   territory_id?: number;
   phone?: string;
   role: string;
+  // Nombre total de périmètres du compte, indépendant du filtre du caller.
+  scopes_count: number;
 };
 export type ResultInterface = {
   meta: {

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
@@ -151,6 +151,7 @@ describe("UsersRepository", () => {
     const result = await repository.deleteUser({ id: createdUserId });
 
     assertEquals(result.success, true);
+    assertEquals(result.outcome, "user_deleted");
     assertEquals(result.message, `user ${createdUserId} deleted`);
 
     // Verify deletion
@@ -252,13 +253,72 @@ describe("UsersRepository multi-scope (pivot)", () => {
     );
   });
 
-  it("delete cascades the pivot rows", async () => {
+  it("delete from a territory only releases that scope", async () => {
     const created = await repository.getUsers({ search: "multi.scope@example.com" });
     const uid = created.data[0].id;
-    await repository.deleteUser({ id: uid, territory_id: 311 });
+    const result = await repository.deleteUser({ id: uid, territory_id: 311 });
+    assertEquals(result.outcome, "scope_released");
+
+    const scopeRows = await db.connection.query<{ territory_id: number }>(sql`
+      SELECT territory_id FROM auth.user_scopes WHERE user_id = ${uid}
+    `);
+    assertEquals(scopeRows.length, 1);
+    assertEquals(scopeRows[0].territory_id, 310);
+
+    const still = await repository.getUsers({ id: uid });
+    assertEquals(still.data.length, 1);
+  });
+
+  it("releasing the default scope promotes another one", async () => {
+    await repository.createUser({
+      firstname: "Promote",
+      lastname: "Scope",
+      email: "promote.scope@example.com",
+      role: "territory.admin" as const,
+      operator_id: null,
+      territory_id: 310,
+      scopes: [311],
+    });
+    const uid = (await repository.getUsers({ search: "promote.scope@example.com" })).data[0].id;
+
+    const result = await repository.deleteUser({ id: uid, territory_id: 310 });
+    assertEquals(result.outcome, "scope_released");
+
+    const rows = await db.connection.query<{ territory_id: number; is_default: boolean }>(sql`
+      SELECT territory_id, is_default FROM auth.user_scopes WHERE user_id = ${uid}
+    `);
+    assertEquals(rows.length, 1);
+    assertEquals(rows[0].territory_id, 311);
+    assertEquals(rows[0].is_default, true);
+  });
+
+  it("delete of the last scope removes the account and its pivot rows", async () => {
+    const created = await repository.getUsers({ search: "multi.scope@example.com" });
+    const uid = created.data[0].id;
+
+    const result = await repository.deleteUser({ id: uid, territory_id: 310 });
+    assertEquals(result.outcome, "user_deleted");
+
     const scopeRows = await db.connection.query<{ n: number }>(sql`
       SELECT count(*)::int AS n FROM auth.user_scopes WHERE user_id = ${uid}
     `);
     assertEquals(scopeRows[0].n, 0);
+    assertEquals((await repository.getUsers({ id: uid })).data.length, 0);
+  });
+
+  it("operator caller deletes the account (scope 1:1)", async () => {
+    await repository.createUser({
+      firstname: "Op",
+      lastname: "Scope",
+      email: "op.scope@example.com",
+      role: "operator.admin" as const,
+      operator_id: 1,
+      territory_id: null,
+    });
+    const uid = (await repository.getUsers({ search: "op.scope@example.com" })).data[0].id;
+
+    const result = await repository.deleteUser({ id: uid, operator_id: 1 });
+    assertEquals(result.outcome, "user_deleted");
+    assertEquals((await repository.getUsers({ id: uid })).data.length, 0);
   });
 });

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
@@ -243,6 +243,15 @@ describe("UsersRepository multi-scope (pivot)", () => {
     assertEquals(listed.data[0].operator_id, null);
   });
 
+  it("scopes_count compte tous les périmètres, même filtré sur un seul", async () => {
+    const listed = await repository.getUsers({ search: "multi.scope@example.com" });
+    assertEquals(listed.data[0].scopes_count, 2);
+
+    // Filtré sur 310 : le compte n'en expose qu'un, mais en porte bien deux.
+    const byT310 = await repository.getUsers({ territory_id: 310, search: "multi.scope" });
+    assertEquals(byT310.data[0].scopes_count, 2);
+  });
+
   it("delete scoped on a non-granted territory finds nothing", async () => {
     const created = await repository.getUsers({ search: "multi.scope@example.com" });
     const uid = created.data[0].id;

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.integration.spec.ts
@@ -204,7 +204,7 @@ describe("UsersRepository multi-scope (pivot)", () => {
     await after(db);
   });
 
-  it("create dual-writes the pivot (default + extra territories)", async () => {
+  it("create writes the pivot (default + extra territories)", async () => {
     await repository.createUser({
       firstname: "Multi",
       lastname: "Scope",
@@ -236,10 +236,26 @@ describe("UsersRepository multi-scope (pivot)", () => {
     assertEquals(byT311.data.length, 1);
   });
 
+  it("list exposes the default scope of the pivot", async () => {
+    const listed = await repository.getUsers({ search: "multi.scope@example.com" });
+    assertEquals(listed.data[0].territory_id, 310);
+    assertEquals(listed.data[0].operator_id, null);
+  });
+
+  it("delete scoped on a non-granted territory finds nothing", async () => {
+    const created = await repository.getUsers({ search: "multi.scope@example.com" });
+    const uid = created.data[0].id;
+    await assertRejects(
+      async () => await repository.deleteUser({ id: uid, territory_id: 999999 }),
+      NotFoundException,
+      "Not found",
+    );
+  });
+
   it("delete cascades the pivot rows", async () => {
     const created = await repository.getUsers({ search: "multi.scope@example.com" });
     const uid = created.data[0].id;
-    await repository.deleteUser({ id: uid });
+    await repository.deleteUser({ id: uid, territory_id: 311 });
     const scopeRows = await db.connection.query<{ n: number }>(sql`
       SELECT count(*)::int AS n FROM auth.user_scopes WHERE user_id = ${uid}
     `);

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.ts
@@ -1,4 +1,4 @@
-import { NotFoundException, provider } from "@/ilos/common/index.ts";
+import { ConflictException, NotFoundException, provider } from "@/ilos/common/index.ts";
 import { DenoPostgresConnection } from "@/ilos/connection-postgres/index.ts";
 import sql, { join, raw } from "@/lib/pg/sql.ts";
 import { UserScopeRepository } from "@/pdc/services/auth/providers/UserScopeRepository.ts";
@@ -152,31 +152,50 @@ export class UsersRepository implements UsersRepositoryInterface {
   async deleteUser(
     params: DeleteUserParamsInterface & { operator_id?: number; territory_id?: number },
   ): Promise<DeleteUserResultInterface> {
-    // Scoping du caller via le pivot : on ne supprime que si le périmètre est accordé.
-    const filters = [sql`users._id = ${params.id}`];
+    const checks = [];
     if (params.operator_id) {
-      filters.push(sql`EXISTS (
-        SELECT 1 FROM ${raw(this.tableScopes)} us
-        WHERE us.user_id = users._id AND us.operator_id = ${params.operator_id}
-      )`);
+      checks.push(sql`us.operator_id = ${params.operator_id}`);
     }
     if (params.territory_id) {
-      filters.push(sql`EXISTS (
-        SELECT 1 FROM ${raw(this.tableScopes)} us
-        WHERE us.user_id = users._id AND us.territory_id = ${params.territory_id}
-      )`);
+      checks.push(sql`us.territory_id = ${params.territory_id}`);
+    }
+
+    if (checks.length) {
+      const counts = await this.pgConnection.query<{ total: number; granted: number }>(sql`
+        SELECT
+          count(*)::int AS total,
+          count(*) FILTER (WHERE ${join(checks, " OR ")})::int AS granted
+        FROM ${raw(this.tableScopes)} us
+        WHERE us.user_id = ${params.id}
+      `);
+      // Périmètre non accordé (ou compte inconnu) : on refuse.
+      if (!counts.length || counts[0].granted < checks.length) {
+        throw new NotFoundException();
+      }
+      if (counts[0].total > 1) {
+        // Un scope opérateur est 1:1 : multi-périmètres ici = incohérent, on refuse.
+        if (!params.territory_id) {
+          throw new ConflictException(`user ${params.id} has multiple scopes`);
+        }
+        await this.userScopeRepository.removeTerritory(params.id, params.territory_id);
+        return {
+          success: true,
+          message: `territory ${params.territory_id} released for user ${params.id}`,
+          outcome: "scope_released",
+        };
+      }
     }
 
     const query = sql`
       DELETE FROM ${raw(this.table)} AS users
-      WHERE ${join(filters, " AND ")}
+      WHERE users._id = ${params.id}
       RETURNING users._id
     `;
     const rows = await this.pgConnection.query(query);
     if (rows.length !== 1) {
       throw new NotFoundException();
     }
-    return { success: true, message: `user ${params.id} deleted` };
+    return { success: true, message: `user ${params.id} deleted`, outcome: "user_deleted" };
   }
 
   async updateUser(data: UpdateUserDataInterface): Promise<UpdateUserResultInterface> {

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.ts
@@ -57,19 +57,20 @@ export class UsersRepository implements UsersRepositoryInterface {
     const page = params.page || 1;
     const offset = (page - 1) * limit;
     const searchJoin = params.search
-      ? sql`LEFT JOIN ${raw(this.tableTerritory)} tg ON tg._id = users.territory_id LEFT JOIN ${
+      ? sql`LEFT JOIN ${raw(this.tableTerritory)} tg ON tg._id = us.territory_id LEFT JOIN ${
         raw(this.tableOperator)
-      } o ON o._id = users.operator_id`
+      } o ON o._id = us.operator_id`
       : sql``;
-    // GROUP BY users._id (PK) : un user multi-territoires n'apparaît qu'une fois.
+    // GROUP BY users._id (PK) : un user multi-territoires n'apparaît qu'une fois ;
+    // le périmètre exposé est son scope par défaut dans le pivot.
     const query = sql`
       SELECT
         users._id as id,
         users.firstname,
         users.lastname,
         users.email,
-        users.operator_id,
-        users.territory_id,
+        (ARRAY_AGG(us.operator_id ORDER BY us.is_default DESC, us._id ASC))[1] AS operator_id,
+        (ARRAY_AGG(us.territory_id ORDER BY us.is_default DESC, us._id ASC))[1] AS territory_id,
         users.role
       FROM ${raw(this.table)} AS users
       LEFT JOIN ${raw(this.tableScopes)} us ON us.user_id = users._id
@@ -102,17 +103,14 @@ export class UsersRepository implements UsersRepositoryInterface {
   }
 
   async createUser(data: CreateUserDataInterface): Promise<CreateUserResultInterface> {
-    // Dual-write (expand) : on écrit encore les colonnes dépréciées operator_id/territory_id + login_siren.
     const query = sql`
       INSERT INTO ${raw(this.table)} (
-        firstname, lastname, email, role, operator_id, territory_id, login_siren
+        firstname, lastname, email, role, login_siren
       ) VALUES (
-        ${data.firstname}, ${data.lastname}, ${data.email}, ${data.role}, ${data.operator_id}, ${data.territory_id}, ${
-      data.login_siren ?? null
-    }
+        ${data.firstname}, ${data.lastname}, ${data.email}, ${data.role}, ${data.login_siren ?? null}
       )
       RETURNING
-        _id, created_at, firstname, lastname, email, role, operator_id, territory_id
+        _id, created_at, firstname, lastname, email, role
     `;
     const rows = await this.pgConnection.query<{ _id: number }>(query);
     if (rows.length !== 1) {
@@ -154,18 +152,25 @@ export class UsersRepository implements UsersRepositoryInterface {
   async deleteUser(
     params: DeleteUserParamsInterface & { operator_id?: number; territory_id?: number },
   ): Promise<DeleteUserResultInterface> {
-    const filters = [sql`_id = ${params.id}`];
+    // Scoping du caller via le pivot : on ne supprime que si le périmètre est accordé.
+    const filters = [sql`users._id = ${params.id}`];
     if (params.operator_id) {
-      filters.push(sql`operator_id = ${params.operator_id}`);
+      filters.push(sql`EXISTS (
+        SELECT 1 FROM ${raw(this.tableScopes)} us
+        WHERE us.user_id = users._id AND us.operator_id = ${params.operator_id}
+      )`);
     }
     if (params.territory_id) {
-      filters.push(sql`territory_id = ${params.territory_id}`);
+      filters.push(sql`EXISTS (
+        SELECT 1 FROM ${raw(this.tableScopes)} us
+        WHERE us.user_id = users._id AND us.territory_id = ${params.territory_id}
+      )`);
     }
 
     const query = sql`
-      DELETE FROM ${raw(this.table)}
+      DELETE FROM ${raw(this.table)} AS users
       WHERE ${join(filters, " AND ")}
-      RETURNING _id
+      RETURNING users._id
     `;
     const rows = await this.pgConnection.query(query);
     if (rows.length !== 1) {
@@ -175,7 +180,6 @@ export class UsersRepository implements UsersRepositoryInterface {
   }
 
   async updateUser(data: UpdateUserDataInterface): Promise<UpdateUserResultInterface> {
-    // Dual-write (expand) : colonnes dépréciées + login_siren, puis resynchro du pivot.
     const query = sql`
       UPDATE ${raw(this.table)}
       SET
@@ -183,12 +187,10 @@ export class UsersRepository implements UsersRepositoryInterface {
         lastname = ${data.lastname},
         email = ${data.email},
         role = ${data.role},
-        operator_id = ${data.operator_id},
-        territory_id = ${data.territory_id},
         login_siren = ${data.login_siren ?? null},
         updated_at = now()
       WHERE _id = ${data.id}
-      RETURNING _id, updated_at, firstname, lastname, email, role, operator_id, territory_id
+      RETURNING _id, updated_at, firstname, lastname, email, role
     `;
     const rows = await this.pgConnection.query<UpdateUserResultInterface>(query);
     if (rows.length !== 1) {

--- a/api/src/pdc/services/dashboard/providers/UsersRepository.ts
+++ b/api/src/pdc/services/dashboard/providers/UsersRepository.ts
@@ -71,7 +71,10 @@ export class UsersRepository implements UsersRepositoryInterface {
         users.email,
         (ARRAY_AGG(us.operator_id ORDER BY us.is_default DESC, us._id ASC))[1] AS operator_id,
         (ARRAY_AGG(us.territory_id ORDER BY us.is_default DESC, us._id ASC))[1] AS territory_id,
-        users.role
+        users.role,
+        -- Sous-requête : le WHERE dégrade le LEFT JOIN en jointure interne, il ne verrait
+        -- que les scopes du caller.
+        (SELECT COUNT(*) FROM ${raw(this.tableScopes)} s WHERE s.user_id = users._id)::int AS scopes_count
       FROM ${raw(this.table)} AS users
       LEFT JOIN ${raw(this.tableScopes)} us ON us.user_id = users._id
       ${searchJoin}


### PR DESCRIPTION
Dernière tranche de GEN-686 : `auth.user_scopes` devient la seule source de vérité des périmètres.

- retrait du dual-write dans `UsersRepository` (create/update n'écrivent plus les colonnes, liste et suppression passent par le pivot) ;
- `DenoMigrator` et `LegacyMigrator` alimentent le pivot au lieu des colonnes legacy ;
- migration `20260907120000` : `DROP COLUMN operator_id, territory_id` sur `auth.users` ;
- tests d'intégration adaptés, dont le cas d'un compte sans périmètre.

Contrôles de cohérence du pivot rejoués en production avant écriture de la migration : aucun périmètre manquant, aucun défaut divergent, aucun compte sans défaut.

Migration destructive et forward-only : à déployer une fois ce code présent sur tous les pods.
