### PR TITLE
fix(api): fait échouer les migrations SQL au lieu de les avaler

### DIFF
--- a/api/src/db/migrations/20260703000000-datalake-fdw-export.sql
+++ b/api/src/db/migrations/20260703000000-datalake-fdw-export.sql
@@ -137,13 +137,20 @@ FROM anomaly.labels;
 
 -- ================= carpool v1 (TEMPORAIRE : suppr après consolidation trusted) =================
 
-CREATE OR REPLACE VIEW dlk_export.carpool_carpools AS
+-- carpool v1 : table absente des bases neuves (elle ne vient que du dump flashé).
+DO $$
+BEGIN
+  IF to_regclass('carpool.carpools') IS NOT NULL THEN
+    EXECUTE 'CREATE OR REPLACE VIEW dlk_export.carpool_carpools AS
 SELECT
   _id, created_at, acquisition_id, operator_id, trip_id, operator_trip_id, is_driver,
   operator_class, datetime, duration, start_position, end_position, distance, seats,
   operator_journey_id, cost, meta, status::text AS status,
   start_territory_id, end_territory_id, start_geo_code, end_geo_code, payment
-FROM carpool.carpools;
+FROM carpool.carpools;';
+  END IF;
+END
+$$;
 
 -- ================= cee (TEMPORAIRE : CEE déprécié) =================
 
@@ -160,8 +167,14 @@ FROM cee.cee_applications;
 --  Droits pour datalake_fdw (lecture seule, user créé par OpenTofu PR #36)
 -- =====================================================================
 
-GRANT USAGE   ON SCHEMA   dlk_export              TO datalake_fdw;
-GRANT SELECT  ON ALL TABLES IN SCHEMA dlk_export  TO datalake_fdw;
-
--- Auto-grant SELECT sur les futures vues créées par vnm dans dlk_export :
-ALTER DEFAULT PRIVILEGES IN SCHEMA dlk_export GRANT SELECT ON TABLES TO datalake_fdw;
+-- Le rôle est créé par OpenTofu : absent des bases de test/dev, où l'on saute les droits.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'datalake_fdw') THEN
+    GRANT USAGE  ON SCHEMA   dlk_export             TO datalake_fdw;
+    GRANT SELECT ON ALL TABLES IN SCHEMA dlk_export TO datalake_fdw;
+    -- Auto-grant SELECT sur les futures vues créées par vnm dans dlk_export :
+    ALTER DEFAULT PRIVILEGES IN SCHEMA dlk_export GRANT SELECT ON TABLES TO datalake_fdw;
+  END IF;
+END
+$$;

--- a/api/src/pdc/providers/migration/migrations.ts
+++ b/api/src/pdc/providers/migration/migrations.ts
@@ -42,29 +42,28 @@ export async function migrateSQL(connectionString: string, path: string, verbose
         await transaction.queryArray`INSERT INTO public.migrations (name, run_on) VALUES (${td}, NOW())`;
         await transaction.commit();
       } catch (e) {
-        // There's no way to catch the database error to log it.
-        // Run the file with psql to debug...
         logger.error(`Error in migration: ${td}`);
-        if (e instanceof Error) {
-          logger.error(e.message);
-        } else {
-          logger.error("An unknown error occurred");
-        }
+        logger.error(migrationErrorMessage(e));
+        throw e;
       } finally {
         await migClient.end();
       }
     }
   } catch (e) {
     logger.error("Error in migrateSQL");
-    if (e instanceof Error) {
-      logger.error(e.message);
-    } else {
-      logger.error("An unknown error occurred");
-    }
+    logger.error(migrationErrorMessage(e));
+    throw e;
   } finally {
     conn.release();
     await pool.end();
   }
+}
+
+// deno-postgres masque l'erreur SQL derrière « transaction has been aborted » : le détail est dans cause.
+function migrationErrorMessage(e: unknown): string {
+  if (!(e instanceof Error)) return "An unknown error occurred";
+  const cause = e.cause instanceof Error ? e.cause.message : undefined;
+  return cause ? `${e.message} — ${cause}` : e.message;
 }
 
 async function getPossibleMigrationsFilePath(path: string): Promise<Map<string, string>> {


### PR DESCRIPTION
Les deux `catch` de `migrateSQL` journalisaient l'erreur puis poursuivaient : une migration en échec laissait le déploiement se terminer en succès apparent, colonnes ou objets manquants. Elles relancent désormais l'erreur, et le message SQL réel est extrait de `cause` (deno-postgres le masque derrière « transaction has been aborted »).

Ce durcissement exhume une panne dormante, corrigée ici : `20260703000000-datalake-fdw-export` échouait sur **toute base neuve** — la vue `carpool_carpools` vise une table v1 qui ne vient que du dump flashé, et les `GRANT` visent un rôle créé par OpenTofu. Les deux sont désormais conditionnés à l'existence de leur cible. Les bases de test n'avaient donc jamais les vues `dlk_export` depuis juillet.

Extrait de la PR #3348 (GEN-686 T6), à merger avant elle : la garde de la migration de contract n'a d'effet que si un échec de migration fait vraiment échouer le déploiement.