### PR TITLE
feat(datalake): modèle de recherche de territoires observatory_search…

### DIFF
--- a/datalake/README.md
+++ b/datalake/README.md
@@ -262,7 +262,7 @@ Charge les données IGN 2025 (GPKG), CEREMA AOMs, mouvements INSEE, campagnes et
 just pipeline-trusted-geo
 ```
 
-Construit la hiérarchie géographique dans `zone_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools. Les tables `perimeters`/`perimeters_agg` sont reconstruites par `DROP … CASCADE`, ce qui supprime les vues aval de `zone_exposed` : la recette enchaîne donc systématiquement un `dbt run` des vues exposées.
+Construit la hiérarchie géographique dans `zone_trusted` (`perimeters`, `perimeters_agg`, `com_evolution`). Base pour tous les JOINs géographiques des carpools. Les tables `perimeters`/`perimeters_agg` sont reconstruites par `DROP … CASCADE`, ce qui supprime les vues aval de `zone_exposed` (et laisse les tables aval sur l'ancien millésime) : la recette enchaîne donc systématiquement un `dbt run` de toute la zone exposée.
 
 ### Étape 2 bis — Stats des tables distantes (FDW)
 

--- a/datalake/justfile
+++ b/datalake/justfile
@@ -128,8 +128,9 @@ pipeline-raw *args:
 pipeline-trusted-geo *args:
   just dbt run --select "tag:trusted,tag:geo" {{args}}
   # perimeters/perimeters_agg sont des tables : dbt les reconstruit par DROP … CASCADE,
-  # ce qui supprime les vues aval de zone_exposed. On les recrée.
-  just dbt run --select "models/exposed,config.materialized:view" {{args}}
+  # ce qui supprime les vues aval de zone_exposed (et laisse les tables aval, ex.
+  # observatory_search_territories, sur l'ancien millésime). On rejoue tout l'exposé.
+  just dbt run --select "models/exposed" {{args}}
 
 # Pipeline 3 : daily update (agrégés taggés daily + zone exposée + invalidation du cache).
 # Un seul `dbt run` sur l'union => dbt ordonne le DAG (agrégés frais avant l'exposé).

--- a/datalake/models/exposed/observatory/observatory_search_territories.sql
+++ b/datalake/models/exposed/observatory/observatory_search_territories.sql
@@ -1,0 +1,65 @@
+{{ config(
+    materialized='table',
+    tags=['exposed', 'observatory', 'search', 'territories'],
+    post_hook=[
+      "CREATE UNIQUE INDEX IF NOT EXISTS {{ this.name }}_key_idx ON {{ this }} (territory, type, year)",
+      "CREATE UNIQUE INDEX IF NOT EXISTS {{ this.name }}_id_latest_idx ON {{ this }} (id) WHERE is_latest",
+      "CREATE INDEX IF NOT EXISTS {{ this.name }}_id_idx ON {{ this }} (id)",
+      "CREATE INDEX IF NOT EXISTS {{ this.name }}_label_trgm_idx ON {{ this }} USING gin (public.immutable_unaccent(lower(l_territory)) public.gin_trgm_ops)",
+      "CREATE INDEX IF NOT EXISTS {{ this.name }}_type_latest_idx ON {{ this }} (type, is_latest)",
+    ]
+) }}
+
+-- Référentiel plat « un territoire recherchable par ligne » pour l'autocomplete de
+-- sélection de territoire de l'observatoire (remplace l'index Meilisearch `geo`).
+--
+-- Grain : une ligne par (territory, type, year). `id` = territory || '_' || type
+-- est la clé métier d'un territoire, année exclue : elle se répète d'un millésime
+-- à l'autre (unique seulement au sein d'un `year`, et parmi les lignes
+-- `is_latest`). La résolution exacte d'un `id` par l'API se fait sur `is_latest`.
+--
+-- Multi-millésime : `is_latest` isole le dernier référentiel (comportement de
+-- l'index Meilisearch actuel), `year` permet de cibler un millésime précis.
+--
+-- Source : `perimeters_agg`, déjà éclaté par niveau (com/epci/aom/dep/reg/country)
+-- et dédoublonné par `mode()` sur le libellé. On écarte :
+--   * le sentinel étranger `XXXXX` ;
+--   * l'artefact « pays agrégé en type=com » que `perimeters_agg` ajoute pour les
+--     modèles od_* — il ferait un doublon de `code` avec la ligne `type=country`.
+--
+-- La recherche insensible aux accents s'appuie sur l'index GIN trigram
+-- `immutable_unaccent(lower(l_territory))` (cf. migration `0005_search_extensions`).
+
+WITH latest_millesime AS (
+  SELECT max(year) AS year FROM {{ ref('perimeters_agg') }}
+),
+
+territories AS (
+  SELECT
+    pa.year,
+    pa.code,
+    pa.type,
+    pa.libelle
+  FROM {{ ref('perimeters_agg') }} AS pa
+  WHERE
+    pa.code IS NOT NULL
+    AND pa.code <> 'XXXXX'
+    AND NOT (
+      pa.type = 'com'
+      AND EXISTS (
+        SELECT 1
+        FROM {{ ref('perimeters_agg') }} AS c
+        WHERE c.type = 'country' AND c.code = pa.code AND c.year = pa.year
+      )
+    )
+)
+
+SELECT
+  t.code || '_' || t.type                     AS id,
+  t.code                                       AS territory,
+  mode() WITHIN GROUP (ORDER BY t.libelle)     AS l_territory,
+  t.type,
+  t.year,
+  t.year = (SELECT year FROM latest_millesime) AS is_latest
+FROM territories AS t
+GROUP BY t.code, t.type, t.year

--- a/datalake/models/exposed/observatory/yml/_observatory_search_territories.yml
+++ b/datalake/models/exposed/observatory/yml/_observatory_search_territories.yml
@@ -1,0 +1,44 @@
+version: 2
+models:
+  - name: observatory_search_territories
+    description: >
+      Référentiel plat « un territoire recherchable par ligne » pour l'autocomplete de
+      sélection de territoire de l'observatoire (remplace l'index Meilisearch geo).
+      Multi-millésime : `is_latest` isole le dernier référentiel, `year` cible un
+      millésime précis. Recherche insensible aux accents via l'index GIN trigram
+      `immutable_unaccent(lower(l_territory))` (migration 0005_search_extensions).
+    columns:
+      - name: id
+        data_type: text
+        description: >
+          `territory` || '_' || `type` — clé métier d'un territoire, année exclue.
+          NON unique dans la table (se répète par millésime) ; unique parmi les
+          lignes `is_latest`. Grain de la table : (territory, type, year).
+        data_tests:
+          - not_null
+      - name: territory
+        data_type: character varying
+        description: Code du territoire (INSEE commune, code EPCI / AOM / département / région, code pays).
+        data_tests:
+          - not_null
+      - name: l_territory
+        data_type: character varying
+        description: Libellé du territoire (dominant si le libellé varie sur le millésime).
+        data_tests:
+          - not_null
+      - name: type
+        data_type: text
+        description: Niveau du territoire.
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ['com', 'epci', 'aom', 'dep', 'reg', 'country']
+      - name: year
+        data_type: integer
+        data_tests:
+          - not_null
+      - name: is_latest
+        data_type: boolean
+        description: Vrai pour les lignes du dernier millésime disponible.
+        data_tests:
+          - not_null


### PR DESCRIPTION
…_territories

Table plate « un territoire recherchable par ligne » dans zone_exposed, socle de l'autocomplete de sélection de territoire de l'observatoire (remplacement de l'index Meilisearch « geo »).

- grain (territory, type, year) ; id = territory_type est la clé métier d'un territoire, année exclue (référence stable côté front)
- multi-millésime : colonnes year + is_latest filtrables
- source perimeters_agg, avec exclusion du sentinel XXXXX et de l'artefact « pays agrégé en type=com » (doublon de code avec type=country)
- index : unique (territory, type, year) ; unique partiel (id) WHERE is_latest ; GIN trigram immutable_unaccent(lower(l_territory)) pour la recherche insensible aux accents
- pipeline-trusted-geo rejoue désormais toute la zone exposée : le run limité aux vues ne rafraîchissait pas cette table après un nouveau millésime

Validé sur postgis:17 avec un jeu de données factice : dbt run + tests, recherche désaccentuée ("ile de france" -> "Île-de-France"), résolution exacte d'un id sur is_latest, et Bitmap Index Scan effectif sur le GIN trigram.

#fixes (issues)

## Description

<!-- compléter ici -->

## Checklist

- [ ] [j'ai suivi les guidelines du "clean code"](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
- [ ] j'ai mis à jour la documentation technique dans `/api/specs`
- [ ] ajout ou mise à jour des tests unitaires
- [ ] ajout ou mise à jour des tests d'intégration

## Merge

Je squash la PR et vérifie que le message de commit utilise [la convention d'Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) :

<details>
<summary>Voir la convention de message de commit...</summary>

```
<type>(<scope>): <short summary>
  │       │             │
  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
  │       │
  │       └─⫸ Commit Scope: proxy|acquisition|export|...
  │
  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
```
Types de commit

 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (examples: Github Actions)
 - docs: Documentation only changes
 - feat: A new feature (Minor bump)
 - fix: A bug fix (Patch bump)
 - perf: A code change that improves performance
 - refactor: A code change that neither fixes a bug nor adds a feature
 - test: Adding missing tests or correcting existing tests

Le _scope_ (optionnel) précise le module ou le composant impacté par le commit.
</details>