### PR TITLE
feat(datalake): route de recherche de territoires dans api-datalake

### DIFF
--- a/api-datalake/README.md
+++ b/api-datalake/README.md
@@ -74,6 +74,9 @@ just test              # pytest
 - [x] Squelette FastAPI + cache + fenêtre de publication
 - [x] Modèles dbt `zone_exposed.{location, observatory_perimeters, campaigns, aires_covoiturage}` — validés sur prod
 - [x] `GET /v3/observatory/location`, `campaigns`, `last-record`
+- [x] `GET /v3/observatory/territories/search` — autocomplete de territoires
+      (modèle `zone_exposed.observatory_search_territories` + index GIN trigram,
+      insensible aux accents ; remplace l'index Meilisearch `geo`)
 - [x] **Endpoints agrégés** : `flux`, `best-flux`, `evol-flux`, `incentive`,
       `occupation`, `best-territories`, `evol-occupation`, `journeys-by-hours`,
       `journeys-by-distances`, `keyfigures`, `aires-covoiturage`

--- a/api-datalake/src/api_datalake/config.py
+++ b/api-datalake/src/api_datalake/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     redis_url: str | None = None
     redis_ca: str | None = None  # CA privée (PEM) pour Redis TLS ; None en dev clair
     cache_ttl_seconds: int = 24 * 3600
+    # TTL dédié aux endpoints à espace de clés large (recherche texte libre) :
+    # borne la croissance mémoire Redis sur les termes tapés une seule fois.
+    search_cache_ttl_seconds: int = 3600
 
     # Fenêtre de publication (borne supérieure exclusive, YYYY-MM-DD)
     app_observatory_published_until: str | None = None

--- a/api-datalake/src/api_datalake/repositories/observatory.py
+++ b/api-datalake/src/api_datalake/repositories/observatory.py
@@ -145,3 +145,80 @@ async def get_last_record(conn, type_: str, code: str,
     if not row:
         return None
     return {"year": row["year"], "month": row["month"]}
+
+
+# --------------------------------------------------------------------------- #
+# Recherche de territoires (autocomplete) — remplace l'index Meilisearch `geo`.
+# Source : zone_exposed.observatory_search_territories (modèle dbt + index GIN trgm).
+# --------------------------------------------------------------------------- #
+
+SEARCH_TABLE = "zone_exposed.observatory_search_territories"
+SEARCH_COLUMNS = ("id", "territory", "l_territory", "type", "year")
+
+# En dessous de 3 caractères, `q` n'a aucun trigramme : l'index GIN est inopérant
+# et un `LIKE '%q%'` dégénère en seq scan. On ne garde alors que la résolution
+# exacte (id / code de territoire), qui reste servie par un index btree.
+SEARCH_MIN_FUZZY_LEN = 3
+
+# `%` et `_` sont des jokers LIKE. On les neutralise (ainsi que `\`) pour que `q`
+# reste une sous-chaîne littérale — sinon `q="_"` matche tout et force un scan
+# large. Le `ESCAPE '\'` explicite dans la requête fige le caractère d'échappement.
+_LIKE_METACHARS = str.maketrans({"\\": r"\\", "%": r"\%", "_": r"\_"})
+
+
+def build_territory_search_query(q: str, limit: int = 20,
+                                 year: int | None = None) -> tuple[str, dict]:
+    """Requête d'autocomplete de territoires + résolution exacte d'un `id`.
+
+    - `q` >= 3 caractères : sous-chaîne désaccentuée (`LIKE`) OU proximité
+      trigramme (`%`), toutes deux accélérées par l'index GIN du modèle ;
+    - `q` plus court : résolution exacte seulement, pour éviter un seq scan sur
+      un motif non indexable ;
+    - dans tous les cas, égalité `id` / `territory` — servie par les index btree
+      du modèle et casse préservée (le front résout par l'`id` stocké tel quel).
+
+    Millésime : `year` explicite, sinon le dernier (`is_latest`). Valeurs liées
+    (`%(...)s`) ; `%%` dans la chaîne = littéral.
+    """
+    q = q.strip()
+    params: dict = {"q_exact": q, "q": q.lower(), "limit": limit}
+
+    year_clause = "is_latest"
+    if year is not None:
+        year_clause = "year = %(year)s"
+        params["year"] = year
+
+    exact = "(id = %(q_exact)s OR territory = %(q_exact)s)"
+    where_or = [exact]
+    order_by = [f"{exact} DESC"]
+    if len(q) >= SEARCH_MIN_FUZZY_LEN:
+        params["q_like"] = f"%{q.lower().translate(_LIKE_METACHARS)}%"
+        where_or[:0] = [
+            "public.immutable_unaccent(lower(l_territory)) "
+            "LIKE public.immutable_unaccent(%(q_like)s) ESCAPE '\\'",
+            "public.immutable_unaccent(lower(l_territory)) "
+            "%% public.immutable_unaccent(%(q)s)",
+        ]
+        order_by.append(
+            "similarity(public.immutable_unaccent(lower(l_territory)), "
+            "public.immutable_unaccent(%(q)s)) DESC")
+    order_by.append("length(l_territory) ASC")
+
+    cols = ", ".join(SEARCH_COLUMNS)
+    sql = f"""
+        SELECT {cols}
+        FROM {SEARCH_TABLE}
+        WHERE {year_clause}
+          AND ({" OR ".join(where_or)})
+        ORDER BY {", ".join(order_by)}
+        LIMIT %(limit)s
+    """
+    return sql, params
+
+
+async def search_territories(conn, q: str, limit: int = 20,
+                             year: int | None = None) -> list[dict]:
+    sql, params = build_territory_search_query(q, limit, year)
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+        return list(await cur.fetchall())

--- a/api-datalake/src/api_datalake/routers/observatory.py
+++ b/api-datalake/src/api_datalake/routers/observatory.py
@@ -44,12 +44,16 @@ def _gzip_json(blob: bytes, cache_state: str) -> Response:
     )
 
 
-async def _serve_cached(redis, route: str, params: dict, produce, acquire) -> Response:
+async def _serve_cached(redis, route: str, params: dict, produce, acquire,
+                        ttl: int | None = None) -> Response:
     """Sert `produce(conn)` (données PG) avec cache Redis best-effort.
 
     La connexion n'est ouverte (`acquire()`) que sur cache MISS, et relâchée dès la
     requête terminée — avant la sérialisation/gzip. Une panne Redis dégrade en
     cache-miss (`X-Cache: BYPASS`), jamais en 500.
+
+    `ttl` : durée de vie en cache (défaut `cache_ttl_seconds`). Un endpoint à
+    espace de clés large (texte libre) passe un TTL plus court.
     """
     cutoff = settings.app_observatory_published_until
     key = None
@@ -65,7 +69,8 @@ async def _serve_cached(redis, route: str, params: dict, produce, acquire) -> Re
         data = await produce(conn)
     blob = gzip_payload(data)
     if ok:
-        await cache_set(redis, key, blob, settings.cache_ttl_seconds)
+        await cache_set(redis, key, blob,
+                        ttl if ttl is not None else settings.cache_ttl_seconds)
     return _gzip_json(blob, "MISS" if ok else "BYPASS")
 
 
@@ -129,6 +134,35 @@ async def campaigns(
         redis, "/observatory/campaigns", params,
         lambda conn: repo.get_campaigns(conn, type, code, year),
         acquire,
+    )
+
+
+@router.get("/territories/search")
+async def territories_search(
+    q: str = Query(..., min_length=1, max_length=64),
+    limit: int = Query(20, ge=1, le=50),
+    year: int | None = Query(None, ge=2015, le=2100),
+    acquire=Depends(get_conn),
+    redis=Depends(get_redis),
+):
+    """Autocomplete de sélection de territoire (remplace l'index Meilisearch `geo`).
+
+    Recherche de libellé insensible aux accents et à la casse, tolérante aux fautes
+    de frappe (>= 3 caractères). Sert aussi la résolution exacte d'un `id`
+    (`territory_type`, casse préservée). `year` cible un millésime ; par défaut le
+    dernier disponible. Réponse gzip cachée.
+    """
+    q = q.strip()
+    if not q:
+        return _gzip_json(gzip_payload([]), "BYPASS")
+    params = {"q": q, "limit": limit, "year": year}
+    return await _serve_cached(
+        redis, "/observatory/territories/search", params,
+        lambda conn: repo.search_territories(conn, q, limit, year),
+        acquire,
+        # espace de clés large (texte libre) -> TTL court, on ne veut pas garder
+        # 24 h chaque terme tapé une seule fois.
+        ttl=settings.search_cache_ttl_seconds,
     )
 
 

--- a/api-datalake/tests/test_territory_search.py
+++ b/api-datalake/tests/test_territory_search.py
@@ -1,0 +1,135 @@
+from contextlib import asynccontextmanager
+
+from fastapi.testclient import TestClient
+
+from api_datalake.cache import get_redis
+from api_datalake.main import create_app
+from api_datalake.repositories.observatory import build_territory_search_query
+from api_datalake.routers.observatory import get_conn
+
+# --- build_territory_search_query : SQL pur, testable sans base ---
+
+
+def test_search_reads_only_exposed_zone():
+    sql, _ = build_territory_search_query("paris", 20)
+    assert "zone_exposed.observatory_search_territories" in sql
+    for forbidden in ("zone_trusted.", "zone_raw.", "zone_aggregated."):
+        assert forbidden not in sql
+
+
+def test_search_binds_every_value():
+    sql, params = build_territory_search_query("  Île-de-France  ", 15, year=2025)
+    # q trim ; casse préservée pour l'exact, lower pour le flou ; valeurs liées
+    assert params["q_exact"] == "Île-de-France"
+    assert params["q"] == "île-de-france"
+    assert params["limit"] == 15 and params["year"] == 2025
+    assert "%(q_exact)s" in sql and "%(limit)s" in sql and "%(year)s" in sql
+    # aucune valeur brute interpolée
+    assert "Île-de-France" not in sql
+    assert "year = %(year)s" in sql
+
+
+def test_search_exact_match_is_case_sensitive_and_unindexed_columns():
+    sql, _ = build_territory_search_query("11_reg", 20)
+    # comparé aux colonnes brutes (index btree du modèle), pas via lower()
+    assert "id = %(q_exact)s OR territory = %(q_exact)s" in sql
+
+
+def test_search_defaults_to_latest_millesime():
+    sql, params = build_territory_search_query("lyon", 20)
+    assert "is_latest" in sql
+    assert "year" not in params
+
+
+def test_search_uses_accent_insensitive_and_trigram():
+    sql, params = build_territory_search_query("lyon", 20)
+    assert "public.immutable_unaccent" in sql
+    assert "LIKE" in sql
+    assert "%%" in sql  # opérateur trigram + wildcards LIKE, échappés
+    assert "similarity(" in sql
+    assert params["q_like"] == "%lyon%"
+
+
+def test_search_short_query_is_exact_match_only():
+    # < 3 caractères : aucun trigramme utile -> pas de LIKE ni de similarity,
+    # seulement la résolution exacte (sinon seq scan sur motif non indexable).
+    sql, params = build_territory_search_query("84", 20)
+    assert "LIKE" not in sql
+    assert "similarity(" not in sql
+    assert "%%" not in sql
+    assert "q_like" not in params
+    assert "id = %(q_exact)s OR territory = %(q_exact)s" in sql
+
+
+def test_search_escapes_like_metacharacters():
+    _, params = build_territory_search_query("a_b%c\\d", 20)
+    # jokers LIKE neutralisés : q reste une sous-chaîne littérale
+    assert params["q_like"] == r"%a\_b\%c\\d%"
+
+
+# --- endpoint /observatory/territories/search ---
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, sql, params):
+        pass
+
+    async def fetchall(self):
+        return self._rows
+
+
+class FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return FakeCursor(self._rows)
+
+
+def _client(rows):
+    app = create_app()
+
+    def override_conn():
+        @asynccontextmanager
+        async def _acquire():
+            yield FakeConn(rows)
+        return _acquire
+
+    app.dependency_overrides[get_conn] = override_conn
+    app.dependency_overrides[get_redis] = lambda: None
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_search_endpoint_returns_gzipped_list():
+    rows = [{"id": "75056_com", "territory": "75056", "l_territory": "Paris",
+             "type": "com", "year": 2026}]
+    r = _client(rows).get("/observatory/territories/search", params={"q": "pari"})
+    assert r.status_code == 200
+    assert r.headers["content-encoding"] == "gzip"
+    assert r.json() == rows
+
+
+def test_search_blank_query_returns_empty_without_db():
+    r = _client([{"id": "x"}]).get("/observatory/territories/search", params={"q": "   "})
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_search_query_too_long_is_422():
+    r = _client([]).get("/observatory/territories/search", params={"q": "a" * 65})
+    assert r.status_code == 422
+    assert r.json() == {"detail": "invalid request parameters"}
+
+
+def test_search_limit_out_of_range_is_422():
+    r = _client([]).get("/observatory/territories/search", params={"q": "paris", "limit": 200})
+    assert r.status_code == 422


### PR DESCRIPTION
GET /observatory/territories/search?q=&limit=&year= — autocomplete de sélection de territoire (remplace l'appel direct à l'index Meilisearch « geo »).

- lit zone_exposed.observatory_search_territories (modèle + index GIN trgm)
- q >= 3 caractères : sous-chaîne désaccentuée (LIKE) OU proximité trigramme (%), les deux via l'index GIN ; q plus court : résolution exacte seule (pas de motif non indexable)
- égalité id / territory servie par les index btree du modèle, casse préservée (le front résout par l'id stocké tel quel)
- jokers LIKE (%, _, \) neutralisés dans q
- q lié (%(...)s), borné 1..64 ; limit 1..50 ; year optionnel (déf. is_latest)
- réponse gzip cachée, TTL court dédié (search_cache_ttl_seconds = 1 h) vu l'espace de clés large ; q vide -> [] sans toucher la base

Validé : pytest (93), et requête réelle via psycopg sur postgis:17 avec 35k lignes — plan 100 % index (BitmapOr GIN + btree), ~0,5 ms ; accents, tirets manquants, fautes de frappe, résolution exacte d'un id, jokers littéraux.

#fixes (issues)

## Description

<!-- compléter ici -->

## Checklist

- [ ] [j'ai suivi les guidelines du "clean code"](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
- [ ] j'ai mis à jour la documentation technique dans `/api/specs`
- [ ] ajout ou mise à jour des tests unitaires
- [ ] ajout ou mise à jour des tests d'intégration

## Merge

Je squash la PR et vérifie que le message de commit utilise [la convention d'Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) :

<details>
<summary>Voir la convention de message de commit...</summary>

```
<type>(<scope>): <short summary>
  │       │             │
  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
  │       │
  │       └─⫸ Commit Scope: proxy|acquisition|export|...
  │
  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
```
Types de commit

 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (examples: Github Actions)
 - docs: Documentation only changes
 - feat: A new feature (Minor bump)
 - fix: A bug fix (Patch bump)
 - perf: A code change that improves performance
 - refactor: A code change that neither fixes a bug nor adds a feature
 - test: Adding missing tests or correcting existing tests

Le _scope_ (optionnel) précise le module ou le composant impacté par le commit.
</details>