### PR TITLE
fix(api): durcit l'authentification de DELETE /cache

### DIFF
--- a/api/src/pdc/proxy/HttpTransport.ts
+++ b/api/src/pdc/proxy/HttpTransport.ts
@@ -39,7 +39,12 @@ import { prometheusMetricsFactory } from "./helpers/prometheusMetricsFactory.ts"
 import { CacheMiddleware, cacheMiddleware } from "./middlewares/cacheMiddleware.ts";
 import { dataWrapMiddleware, errorHandlerMiddleware } from "./middlewares/index.ts";
 import { metricsMiddleware } from "./middlewares/metricsMiddleware.ts";
-import { apiRateLimiter, monHonorCertificateRateLimiter, rateLimiter } from "./middlewares/rateLimiter.ts";
+import {
+  apiRateLimiter,
+  authRateLimiter,
+  monHonorCertificateRateLimiter,
+  rateLimiter,
+} from "./middlewares/rateLimiter.ts";
 import { sessionMiddleware } from "./middlewares/sessionMiddleware.ts";
 
 export class HttpTransport implements TransportInterface {
@@ -207,7 +212,7 @@ export class HttpTransport implements TransportInterface {
 
     this.app.delete(
       "/cache",
-      rateLimiter(),
+      authRateLimiter(),
       this.cache.auth(),
       asyncHandler(async (req: Request, res: Response) => {
         const prefix = (req.query.prefix as string | undefined) || "*";

--- a/api/src/pdc/proxy/middlewares/cacheMiddleware.auth.unit.spec.ts
+++ b/api/src/pdc/proxy/middlewares/cacheMiddleware.auth.unit.spec.ts
@@ -1,0 +1,25 @@
+import { assertEquals, assertInstanceOf } from "dep:assert";
+import { describe, it } from "dep:testing-bdd";
+import { ForbiddenException } from "@/ilos/common/index.ts";
+import { NextFunction, Request, Response } from "dep:express";
+import { cacheMiddleware } from "./cacheMiddleware.ts";
+
+function run(authToken: string, header?: string): unknown {
+  const mw = cacheMiddleware({ enabled: false, driver: null, gzipped: false, authToken });
+  let nextArg: unknown = "not-called";
+  const next: NextFunction = (e?: unknown) => (nextArg = e);
+  const req = { headers: header !== undefined ? { "x-route-cache-auth": header } : {} } as unknown as Request;
+  mw.auth()(req, {} as Response, next);
+  return nextArg;
+}
+
+describe("cacheMiddleware.auth", () => {
+  it("passes with the right token", () => assertEquals(run("s3cret", "s3cret"), undefined));
+  it("forbids a wrong token", () => assertInstanceOf(run("s3cret", "nope"), ForbiddenException));
+  it("forbids a missing header", () => assertInstanceOf(run("s3cret"), ForbiddenException));
+  it("errors when the server token is unset", () => {
+    const e = run("", "anything");
+    assertInstanceOf(e, Error);
+    assertEquals((e as Error).message, "Please set APP_ROUTECACHE_AUTHTOKEN");
+  });
+});

--- a/api/src/pdc/proxy/middlewares/cacheMiddleware.ts
+++ b/api/src/pdc/proxy/middlewares/cacheMiddleware.ts
@@ -3,6 +3,7 @@ import { ForbiddenException } from "@/ilos/common/index.ts";
 import { NextFunction, Request, Response } from "dep:express";
 
 import { logger } from "@/lib/logger/index.ts";
+import { safeCompare } from "@/lib/crypto/safeCompare.ts";
 import { cacheStore } from "./cache/redis.ts";
 import { deflate, getKey, inflate } from "./cache/transformers.ts";
 import type {
@@ -142,20 +143,21 @@ export function cacheMiddleware(
     },
 
     auth() {
+      // async signature kept for CacheMiddleware type; body is sync, next(err) not throw (Express 4 doesn't catch async throws)
       return async (
         req: Request,
         res: Response,
         next: NextFunction,
       ): Promise<void> => {
-        const token = String(globalConfig.authToken);
+        const token = String(globalConfig.authToken ?? "");
         const header = req.headers["x-route-cache-auth"];
 
         if (token === "") {
           return next(new Error("Please set APP_ROUTECACHE_AUTHTOKEN"));
         }
 
-        if (token !== header) {
-          throw new ForbiddenException(`Invalid X-Route-Cache-Auth header`);
+        if (typeof header !== "string" || !safeCompare(token, header)) {
+          return next(new ForbiddenException(`Invalid X-Route-Cache-Auth header`));
         }
 
         next();


### PR DESCRIPTION
## Résumé

Durcissement de `DELETE /cache` (vidage du cache de routes, appelé par le CMS).

- comparaison du jeton `X-Route-Cache-Auth` en temps constant via un nouveau helper `safeCompare` (`timingSafeEqual`)
- l'ancien `String(authToken)` transformait un jeton serveur absent en chaîne `"undefined"`, acceptée telle quelle en en-tête : corrigé par `?? ""`
- un `throw` dans un middleware `async` n'était pas intercepté par Express 4 (requête pendante) : remplacé par `next(new ForbiddenException(...))` → 403 JSON
- rate limiter dédié `rl-auth` (100/min) au lieu du limiteur générique (360/min)

En-tête et contrat inchangés côté CMS.

## Vérifications

- CGU : PASS, aucun constat
- Sécurité : PASS (LOW)
- `just test-unit` : 546 passés, 0 échec

## Release

`fix(api)` sur `api/**` → patch, déploiement de l'API.