### PR TITLE
fix(cms): permission RBAC dédiée pour lancer les flows

### DIFF
--- a/cms/src/plugins/betagouv/admin/src/index.tsx
+++ b/cms/src/plugins/betagouv/admin/src/index.tsx
@@ -21,13 +21,7 @@ export default {
 
         return component;
       },
-      permissions: [
-        // Uncomment to set the permissions of the plugin here
-        // {
-        //   action: '', // the action name should be plugin::plugin-name.actionType
-        //   subject: null,
-        // },
-      ],
+      permissions: [{ action: 'plugin::betagouv.flows.run', subject: null }],
     });
     const plugin = {
       id: pluginId,

--- a/cms/src/plugins/betagouv/server/bootstrap.ts
+++ b/cms/src/plugins/betagouv/server/bootstrap.ts
@@ -1,5 +1,12 @@
 import { Strapi } from '@strapi/strapi';
 
-export default ({ strapi }: { strapi: Strapi }) => {
-  // bootstrap phase
+export default async ({ strapi }: { strapi: Strapi }) => {
+  await strapi.admin.services.permission.actionProvider.registerMany([
+    {
+      section: 'plugins',
+      displayName: 'Run flows (flush cache, deploy)',
+      uid: 'flows.run',
+      pluginName: 'betagouv',
+    },
+  ]);
 };

--- a/cms/src/plugins/betagouv/server/policies/has-permission.ts
+++ b/cms/src/plugins/betagouv/server/policies/has-permission.ts
@@ -1,7 +1,0 @@
-export default (policyContext, config, { strapi }) => {
-  if (policyContext.state.user && policyContext.state.user.isActive) {
-    return true;
-  }
-
-  return false;
-};

--- a/cms/src/plugins/betagouv/server/policies/index.ts
+++ b/cms/src/plugins/betagouv/server/policies/index.ts
@@ -1,5 +1,1 @@
-import hasPermission from './has-permission';
-
-export default {
-  hasPermission,  
-};
+export default {};

--- a/cms/src/plugins/betagouv/server/routes/index.ts
+++ b/cms/src/plugins/betagouv/server/routes/index.ts
@@ -1,10 +1,15 @@
+const flowsPolicy = {
+  name: 'admin::hasPermissions',
+  config: { actions: ['plugin::betagouv.flows.run'] },
+};
+
 export default [
   {
     method: 'GET',
     path: '/flows',
     handler: 'flows.index',
     config: {
-      policies: ['plugin::betagouv.hasPermission'],
+      policies: [flowsPolicy],
     },
   },
   {
@@ -12,7 +17,7 @@ export default [
     path: '/flows/:id',
     handler: 'flows.run',
     config: {
-      policies: ['plugin::betagouv.hasPermission'],
+      policies: [flowsPolicy],
     },
   },
 ];


### PR DESCRIPTION
## Résumé

Dans le plugin Strapi `betagouv`, la policy `hasPermission` protégeant les routes `flows` (déploiement des fronts via GitHub Actions, vidage du cache de production) ne vérifiait que `user.isActive` : tout administrateur actif pouvait les déclencher.

- action `plugin::betagouv.flows.run` enregistrée au bootstrap (`actionProvider.registerMany`)
- routes `GET /flows` et `POST /flows/:id` protégées par `admin::hasPermissions` sur cette action
- entrée de menu du plugin conditionnée à la même permission
- ancienne policy supprimée

## Vérifications

- CGU : PASS, aucun constat
- Sécurité : PASS (LOW)
- `npm run build` : OK (Strapi 4.19.1)

## Après déploiement

Seul le rôle Super Admin a la permission par défaut. Pour les autres rôles qui utilisent les flows : Settings › Roles › Plugins › Betagouv › « Run flows ».

## Release

`fix(cms)` : scope `cms`, pas de release semantic-release (le CMS se déploie séparément).
