### PR TITLE
chore(sec): resserre les exclusions talisman

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -31,13 +31,13 @@ fileignoreconfig:
   - filename: docker-compose.base.yml
     checksum: 26800d502eead58a42d2972c5077ef5974e45a3a4cc27734c17ce9a5866a8c06
   - filename: docker-compose.e2e.yml
-    allowed_patterns: ["(?i)pass", "(?i)key"]
+    allowed_patterns: ["POSTGRES_PASSWORD", "APIE2E_AUTH_[A-Z]+_(EMAIL|PASSWORD)"]
   - filename: notebooks/cerema/pdll2025.ipynb
     checksum: 26708491073bd3546e9c811ed788218e7a0e28551e311b25325f870d8eea0a6a
   - filename: api/src/config/connections.ts
     checksum: 243b7f3ec0caaedd588841b5310b9de50fdbe6a81aaf66737bacd57d724f3aa7
   - filename: api/src/lib/crypto/index.ts
-    allowed_patterns: [key]
+    allowed_patterns: [privateKey, importKey]
   - filename: api/src/pdc/services/policy/providers/*.ts
     allowed_patterns: [key]
   - filename: api/src/pdc/services/policy/engine/**/*.ts
@@ -52,45 +52,20 @@ fileignoreconfig:
     ignore_detectors: [filecontent]
   - filename: api/src/ilos/connection-postgres/DenoPostgresConnection.ts
     allowed_patterns: [username, password]
-  - filename: api/src/config/connections.ts
-    checksum: 243b7f3ec0caaedd588841b5310b9de50fdbe6a81aaf66737bacd57d724f3aa7
   - filename: dbt/models/export/dbt_trips.sql
     checksum: 484baa24d66833f4c2ee45a86e7e62c8a677e519a8b5ef6a40b13185721804f2
   - filename: api/src/pdc/providers/migration/*Migrator.ts
     allowed_patterns: [pass]
   - filename: api/e2e/lib/API.ts
-    allowed_patterns:
-      [key, "(?i)secretkey", "(?i)accesskey", "(?i)access", "(?i)secret"]
+    allowed_patterns: [access_key, secret_key, email, password]
   - filename: api/src/pdc/services/auth/actions/CreateAccessTokenAction.ts
-    allowed_patterns:
-      [key, "(?i)secretkey", "(?i)accesskey", "(?i)access", "(?i)secret"]
-  - filename: api/e2e/scenarios/0-stack/004-credentials.test.ts
-    checksum: 6b59470986719df9b04032fb0861d52d0091129c35715b0c5838ad42f280ddab
+    allowed_patterns: [rl-auth, access_key, secret_key, access_token]
   - filename: api/e2e/scenarios/**/*.test.ts
-    allowed_patterns:
-      [
-        key,
-        pass,
-        "(?i)secretkey",
-        "(?i)accesskey",
-        "(?i)password",
-        "(?i)email",
-        "(?i)secret_",
-      ]
-  - filename: api/e2e/lib/*.ts
-    allowed_patterns: ["(?i)key", "(?i)pass"]
+    allowed_patterns: [access_key, secret_key, OPERATOR_EMAIL, OPERATOR_PASSWORD]
   - filename: api/src/pdc/proxy/config/dex.ts
-    allowed_patterns: ["(?i)key", "(?i)secret"]
+    checksum: 76a391078931e9f7bcfbaa75feacfda9ab08d8345ed3dacf0358bad839628223
   - filename: api/e2e/config.ts
-    allowed_patterns:
-      [
-        "(?i)key",
-        "(?i)pass",
-        "(?i)secretkey",
-        "(?i)accesskey",
-        "(?i)password",
-        "(?i)secret",
-      ]
+    checksum: 45620adb108dbb4bb95de1e0cebaf0b41d38e52bbd3adcad218493515ff04a1a
   - filename: app-partners/.env.example
     checksum: 36c5d64bf21daf6fb29fe15a98ece709414d3c7c3b0d350c150aee16354fae0d
   - filename: api/src/pdc/services/auth/providers/DexClient.ts


### PR DESCRIPTION
## Résumé

Les exclusions `.talismanrc` sur les fichiers auth/crypto et les scénarios e2e utilisaient des motifs larges (`key`, `pass`, `(?i)secret`) : tout futur secret contenant un de ces mots dans ces fichiers n'aurait jamais été détecté.

- motifs limités aux identifiants réellement signalés par talisman (`access_key`, `secret_key`, `privateKey`, noms de variables e2e…)
- checksum sur les fichiers stables `api/src/pdc/proxy/config/dex.ts` et `api/e2e/config.ts`
- doublons (`api/e2e/lib/*.ts`, `api/src/config/connections.ts`) et entrée orpheline (`004-credentials.test.ts`, renommé) retirés
- motif `APIE2E_AUTH_[A-Z]+_(EMAIL|PASSWORD)` sur `docker-compose.e2e.yml`, en anticipation de #3371
- test négatif : une fausse clé AWS dans `dex.ts` est bien détectée (checksum invalidé)

`.gitguardian.yaml` n'est pas traité : `ggshield` est absent de l'outillage (ni `flake.nix`, ni `.pre-commit-config.yaml`). À ajouter avant de remplacer `ignored_paths` par `ignored_matches`.

## Vérifications

- CGU : PASS, aucun constat
- Sécurité : PASS (LOW), aucune exclusion élargie
- `talisman --pattern` sur les fichiers concernés : 0 finding

## Release

`chore(sec)` sur un fichier racine : pas de release, aucun déploiement.
