### PR TITLE
chore(api): restreint les permissions Deno du processus API

### DIFF
--- a/api/justfile
+++ b/api/justfile
@@ -11,7 +11,15 @@ docker_compose_proxy_file:=join(parent_directory(justfile_directory()),"docker-c
 # (empty) locally to allow Deno to auto-fetch missing deps.
 deno_cached_only := env_var_or_default("DENO_CACHED_ONLY", "--cached-only")
 deno_allow_import := "--allow-import=cdn.sheetjs.com:443,cdn.esm.sh:443,deno.land:443,raw.githubusercontent.com:443,jsr.io:443"
-deno_flags := "--allow-net --allow-env --allow-read --allow-write --allow-ffi --allow-sys --allow-run --unstable-fs " + deno_allow_import + " " + deno_cached_only
+# Only dirs the API writes to: getTmpDir() (exports, APDF, archives) and the geo cache/download dirs
+deno_write_tmp := env_var_or_default("TMPDIR", env_var_or_default("TMP", env_var_or_default("TEMP", "/tmp")))
+deno_write_cache := env_var_or_default("CACHE_DIRECTORY", deno_write_tmp)
+deno_write_download := env_var_or_default("DOWNLOAD_DIRECTORY", deno_write_cache + "/download")
+deno_allow_write := "--allow-write=" + deno_write_tmp + "," + deno_write_cache + "," + deno_write_download
+# pg_restore (FlashDBData) and 7-Zip (node-7z, geo import), plus an explicit SEVEN_ZIP_BIN_PATH if set
+deno_seven_zip := env_var_or_default("SEVEN_ZIP_BIN_PATH", "")
+deno_run_bins := "pg_restore,7z,7za,7zr" + (if deno_seven_zip != "" { "," + deno_seven_zip } else { "" })
+deno_flags := "--allow-net --allow-env --allow-read --allow-sys --allow-run=" + deno_run_bins + " --unstable-fs " + deno_allow_write + " " + deno_allow_import + " " + deno_cached_only
 
 # List available just commands
 default:


### PR DESCRIPTION
## Résumé

Le processus API tournait avec `--allow-run`, `--allow-ffi` et `--allow-write` sans aucun périmètre, ce qui annulait le bac à sable Deno.

- `--allow-ffi` retiré : aucun usage (bcrypt tourne en Web Worker)
- `--allow-run` limité à `pg_restore` (FlashDBData) et aux binaires 7-Zip (`node-7z`, import géo), plus `SEVEN_ZIP_BIN_PATH` s'il est défini
- `--allow-write` limité au répertoire temporaire (`TMPDIR`/`TMP`/`TEMP`, même cascade que `getTmpDir()`) et aux dossiers `CACHE_DIRECTORY`/`DOWNLOAD_DIRECTORY` du miroir géographique
- `--allow-net`, `--allow-env`, `--allow-read`, `--allow-sys` inchangés (scoper `net` par hôte n'est pas réaliste)

## Vérifications

- CGU : PASS, aucun constat
- Sécurité : PASS, deux régressions signalées (7-Zip, cascade tmp) corrigées avant PR
- `just ci_test_integration` (conteneur `api` avec les vrais flags) : 55 passés, 0 échec ; `just test-unit` : 544 passés
- e2e locaux non concluants (stack en contention), à valider par la CI

## Bugs préexistants relevés, hors périmètre

- `pg_restore` n'est pas installé dans l'image (flash des migrations impossible en conteneur)
- en dev local, le bind mount `./tmp:/tmp` de `docker-compose.dev.yml` appartient à l'utilisateur hôte : le processus (uid 1993) ne peut pas y écrire ; l'image elle-même a bien `/tmp` en 1777, la prod n'est pas concernée

Consignés dans #3376.

## Déploiement

Pas de release (`chore`) : part avec la prochaine version. Recommandé : demo d'abord, surveiller `PermissionDenied` dans les logs 48 h.

