### PR TITLE
fix(datalake): expose la France sous XXXXX_country dans la recherche …

### DIFF
--- a/datalake/models/exposed/observatory/observatory_search_territories.sql
+++ b/datalake/models/exposed/observatory/observatory_search_territories.sql
@@ -10,27 +10,34 @@
     ]
 ) }}
 
--- Référentiel plat « un territoire recherchable par ligne » pour l'autocomplete de
--- sélection de territoire de l'observatoire (remplace l'index Meilisearch `geo`).
+-- Référentiel plat « un territoire recherchable par ligne » pour
+-- l'autocomplete de sélection de territoire de l'observatoire (remplace
+-- l'index Meilisearch `geo`).
 --
--- Grain : une ligne par (territory, type, year). `id` = territory || '_' || type
--- est la clé métier d'un territoire, année exclue : elle se répète d'un millésime
--- à l'autre (unique seulement au sein d'un `year`, et parmi les lignes
--- `is_latest`). La résolution exacte d'un `id` par l'API se fait sur `is_latest`.
+-- Grain : une ligne par (territory, type, year). `id` = territory || '_' ||
+-- type est la clé métier d'un territoire, année exclue : elle se répète
+-- d'un millésime à l'autre (unique seulement au sein d'un `year`, et parmi
+-- les lignes `is_latest`). La résolution exacte d'un `id` par l'API se fait
+-- sur `is_latest`.
 --
--- Multi-millésime : `is_latest` isole le dernier référentiel (comportement de
--- l'index Meilisearch actuel), `year` permet de cibler un millésime précis.
+-- Multi-millésime : `is_latest` isole le dernier référentiel (comportement
+-- de l'index Meilisearch actuel), `year` permet de cibler un millésime
+-- précis.
 --
--- Source : `perimeters_agg`, déjà éclaté par niveau (com/epci/aom/dep/reg/country)
--- et dédoublonné par `mode()` sur le libellé. On écarte :
---   * le doublon `99100` — France telle que codée dans la nomenclature des pays
---     étrangers ; la France est exposée ici sous `XXXXX_country`, code utilisé
---     pour la France dans le reste de l'observatoire (cf. `perimeters.sql`) ;
---   * l'artefact « pays agrégé en type=com » que `perimeters_agg` ajoute pour les
---     modèles od_* — il ferait un doublon de `code` avec la ligne `type=country`.
+-- Source : `perimeters_agg`, déjà éclaté par niveau
+-- (com/epci/aom/dep/reg/country) et dédoublonné par `mode()` sur le
+-- libellé. On écarte :
+--   * le doublon `99100` — France telle que codée dans la nomenclature
+--     des pays étrangers ; la France est exposée ici sous
+--     `XXXXX_country`, code utilisé pour la France dans le reste de
+--     l'observatoire (cf. `perimeters.sql`) ;
+--   * l'artefact « pays agrégé en type=com » que `perimeters_agg` ajoute
+--     pour les modèles od_* — il ferait un doublon de `code` avec la
+--     ligne `type=country`.
 --
 -- La recherche insensible aux accents s'appuie sur l'index GIN trigram
--- `immutable_unaccent(lower(l_territory))` (cf. migration `0005_search_extensions`).
+-- `immutable_unaccent(lower(l_territory))` (cf. migration
+-- `0005_search_extensions`).
 
 WITH latest_millesime AS (
   SELECT max(year) AS year FROM {{ ref('perimeters_agg') }}
@@ -57,11 +64,12 @@ territories AS (
 )
 
 SELECT
-  t.code || '_' || t.type                     AS id,
-  t.code                                       AS territory,
-  mode() WITHIN GROUP (ORDER BY t.libelle)     AS l_territory,
+  t.code                                   AS territory,
   t.type,
   t.year,
-  t.year = (SELECT year FROM latest_millesime) AS is_latest
+  t.code || '_' || t.type                  AS id,
+  t.year = lm.year                         AS is_latest,
+  mode() WITHIN GROUP (ORDER BY t.libelle) AS l_territory
 FROM territories AS t
-GROUP BY t.code, t.type, t.year
+CROSS JOIN latest_millesime AS lm
+GROUP BY t.code, t.type, t.year, lm.year

--- a/datalake/models/exposed/observatory/observatory_search_territories.sql
+++ b/datalake/models/exposed/observatory/observatory_search_territories.sql
@@ -23,7 +23,9 @@
 --
 -- Source : `perimeters_agg`, déjà éclaté par niveau (com/epci/aom/dep/reg/country)
 -- et dédoublonné par `mode()` sur le libellé. On écarte :
---   * le sentinel étranger `XXXXX` ;
+--   * le doublon `99100` — France telle que codée dans la nomenclature des pays
+--     étrangers ; la France est exposée ici sous `XXXXX_country`, code utilisé
+--     pour la France dans le reste de l'observatoire (cf. `perimeters.sql`) ;
 --   * l'artefact « pays agrégé en type=com » que `perimeters_agg` ajoute pour les
 --     modèles od_* — il ferait un doublon de `code` avec la ligne `type=country`.
 --
@@ -43,7 +45,7 @@ territories AS (
   FROM {{ ref('perimeters_agg') }} AS pa
   WHERE
     pa.code IS NOT NULL
-    AND pa.code <> 'XXXXX'
+    AND pa.code <> '99100'
     AND NOT (
       pa.type = 'com'
       AND EXISTS (


### PR DESCRIPTION
…de territoires

Le référentiel observatory_search_territories excluait le code XXXXX en le supposant étranger, alors qu'il désigne la France partout ailleurs dans l'observatoire (cf. perimeters.sql). La France n'était donc trouvable que sous 99100_country, son code dans la nomenclature des pays étrangers, ce qui provoquait un résultat vide (ou un repli sur le territoire le plus proche, ex. Courtry) lors de sa sélection dans le tableau de bord.

On exclut désormais le doublon 99100 et on expose la France sous XXXXX_country, cohérent avec le reste des modèles.

#fixes (issues)

## Description

<!-- compléter ici -->

## Checklist

- [ ] [j'ai suivi les guidelines du "clean code"](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29)
- [ ] j'ai mis à jour la documentation technique dans `/api/specs`
- [ ] ajout ou mise à jour des tests unitaires
- [ ] ajout ou mise à jour des tests d'intégration

## Merge

Je squash la PR et vérifie que le message de commit utilise [la convention d'Angular](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format) :

<details>
<summary>Voir la convention de message de commit...</summary>

```
<type>(<scope>): <short summary>
  │       │             │
  │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
  │       │
  │       └─⫸ Commit Scope: proxy|acquisition|export|...
  │
  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
```
Types de commit

 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (examples: Github Actions)
 - docs: Documentation only changes
 - feat: A new feature (Minor bump)
 - fix: A bug fix (Patch bump)
 - perf: A code change that improves performance
 - refactor: A code change that neither fixes a bug nor adds a feature
 - test: Adding missing tests or correcting existing tests

Le _scope_ (optionnel) précise le module ou le composant impacté par le commit.
</details>